### PR TITLE
Attempt at fixing the refresh thumbnails workflow

### DIFF
--- a/.github/workflows/refresh-thumbnails.yml
+++ b/.github/workflows/refresh-thumbnails.yml
@@ -34,13 +34,7 @@ jobs:
 
             // Fetch with timeout helper
             async function fetchWithTimeout(url, opts = {}) {
-              const controller = new AbortController();
-              const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT);
-              try {
-                return await fetch(url, { ...opts, signal: controller.signal });
-              } finally {
-                clearTimeout(timeout);
-              }
+              return await fetch(url, opts);
             }
 
             const badgeHosts= ['img.shields.io', 'badge.fury.io', 'badgen.net', 'badges.', 'coveralls.io', 'codecov.io', 'travis-ci.', 'ci.appveyor.com', 'github.com/workflows'];
@@ -82,6 +76,7 @@ jobs:
 
             const files = fs.readdirSync(TOOLS_DIR).filter(f => f.endsWith('.md'));
             let updated = 0;
+            let fetchErrors = 0;
 
             for (const file of files) {
               const slug = file.replace(/\.md$/, '');
@@ -157,7 +152,7 @@ jobs:
                         if (buf.length >= MIN_IMAGE_SIZE && (!biggest || buf.length > biggest.size)) {
                           biggest = { url: imgUrl, size: buf.length, buffer: buf };
                         }
-                      } catch {}
+                      } catch (e) { fetchErrors++; }
                     }
 
                     if (biggest) {
@@ -169,7 +164,7 @@ jobs:
                       readmeBuffer = biggest.buffer;
                     }
                     break;
-                  } catch {}
+                  } catch (e) { fetchErrors++; }
                 }
               }
 
@@ -230,6 +225,12 @@ jobs:
             }
 
             console.log(`\n✅ Done! Updated ${updated} thumbnails.`);
+            if (fetchErrors > 0) {
+              console.log(`⚠️ ${fetchErrors} fetch errors occurred during processing.`);
+            }
+            if (updated === 0 && fetchErrors > files.length) {
+              core.setFailed(`All thumbnail fetches failed (${fetchErrors} errors). Check runner environment.`);
+            }
 
       - name: Commit and push changes
         run: |


### PR DESCRIPTION
Noticed how https://github.com/shanselman/TinyToolTown/actions/runs/22029784561 failed silently.

This PR has:

- A potential fix for the actual errors
- A fix for making these issues more visible

Details:

The fetchWithTimeout wrapper using AbortController + setTimeout caused 'Maximum call stack size exceeded' in the github-script@v7 VM context, silently failing every fetch. Replace with plain fetch and add error tracking so the workflow fails visibly when all fetches error out.

Tested on my fork and things were alright there 🤞 