### PR TITLE
chore: refresh featured tools

### DIFF
--- a/.github/featured-history.json
+++ b/.github/featured-history.json
@@ -1,5 +1,23 @@
 {
-  "lastRun": null,
-  "selectedSlugs": [],
-  "lastFeatured": {}
+  "lastRun": "2026-04-14",
+  "selectedSlugs": [
+    "peekdesktop",
+    "bluetoothwave",
+    "simple-icon-file-maker",
+    "tally",
+    "toasty",
+    "fancygist",
+    "3d-maze",
+    "textream"
+  ],
+  "lastFeatured": {
+    "peekdesktop": "2026-04-14",
+    "bluetoothwave": "2026-04-14",
+    "simple-icon-file-maker": "2026-04-14",
+    "tally": "2026-04-14",
+    "toasty": "2026-04-14",
+    "fancygist": "2026-04-14",
+    "3d-maze": "2026-04-14",
+    "textream": "2026-04-14"
+  }
 }

--- a/src/content/tools/3d-maze.md
+++ b/src/content/tools/3d-maze.md
@@ -11,7 +11,7 @@ language: "C#"
 license: "MIT License"
 theme: "retro"
 date_added: "2026-04-10"
-featured: false
+featured: true
 ai_summary: "Relive the nostalgia of the classic Windows 95 3D Maze screensaver with this fun Unity-powered first-person maze explorer that automatically solves itself but lets you roam freely too! It’s a quirky trip down memory lane with psychedelic textures, flipping cameras, and even a maze-running rat for company."
 ai_features: ["🧱 Randomly generated mazes with customizable textures", "🤸‍♂️ Left-hand and right-hand rule automatic maze solving", "🐀 Animated maze critters and flipping camera rocks", "🗺️ Real-time vector map overlay with icon-coded maze elements"]
 ---

--- a/src/content/tools/bluetoothwave.md
+++ b/src/content/tools/bluetoothwave.md
@@ -9,7 +9,7 @@ tags: ["bluetooth", "audio", "windows", "system-tray"]
 language: "C++"
 license: "MIT"
 date_added: "2026-04-13"
-featured: false
+featured: true
 ---
 
 Bluetooth audio playback (A2DP Sink) connector for Windows 10 2004+ and Windows 11. Features A2DP Sink management, native language support, system tray integration, auto-reconnect, and a portable, zero-telemetry design. No installation required.

--- a/src/content/tools/dev-tartan-bagpipe-ballad-generator.md
+++ b/src/content/tools/dev-tartan-bagpipe-ballad-generator.md
@@ -10,7 +10,7 @@ tags: ["fun", "tartan", "bagpipes"]
 language: "JavaScript"
 license: "MIT"
 date_added: "2026-02-16"
-featured: true
+featured: false
 ai_summary: "Turn your GitHub username into a stunning tartan pattern and a killer bagpipe ballad that’s as unique as your code commits—because every dev deserves their own clan anthem and coat of arms! It’s like weaving your digital identity into art and music with a cheeky Scottish twist."
 ai_features: ["🧶 Generates deterministic tartan patterns from any GitHub username", "🎵 Creates a matching bagpipe ballad for your digital clan", "🎨 Uses traditional Scottish dye colors with authentic twill weave simulation", "🖼️ Renders scalable SVG with reflective symmetry and ambient background tiles"]
 ---

--- a/src/content/tools/focus-fern.md
+++ b/src/content/tools/focus-fern.md
@@ -9,7 +9,7 @@ tags: ["productivity", "canvas", "cozy-web"]
 language: "Typescript"
 license: "MIT"
 date_added: "2026-02-13"
-featured: true
+featured: false
 ai_summary: "A delightfully cozy focus timer that grows an adorable pixel plant while you work — the longer you stay focused, the more your little digital fern flourishes, turning productivity into a tiny gardening game."
 ai_features: ["🌱 Unique pixel plants grow in real-time as you maintain focus", "⏱️ Built-in timer keeps your work sessions on track", "🎮 Gamifies productivity by rewarding concentration with plant growth", "🪴 Cozy vibes make deep work feel like tending a digital garden"]
 ---

--- a/src/content/tools/matrix-tetris-screen-saver.md
+++ b/src/content/tools/matrix-tetris-screen-saver.md
@@ -9,7 +9,7 @@ website_url: "https://github.com/LeeHolmes/matrix-tetromino"
 tags: ["screensaver", "matrix", "tetris"]
 language: "C++"
 date_added: "2026-02-16"
-featured: true
+featured: false
 ai_summary: "Dive into a hypnotic blend of falling Tetris blocks and cascading Matrix code that transforms your screen into a retro hacker's dream! It's the perfect way to geek out while your computer chills."
 ai_features: ["🕹️ Classic Tetris gameplay meets Matrix-style visuals", "🖥️ Dynamic screen saver for idle computers", "🎮 Nostalgic pixel art vibes", "🌌 Smooth animation that mesmerizes"]
 ---

--- a/src/content/tools/simple-icon-file-maker.md
+++ b/src/content/tools/simple-icon-file-maker.md
@@ -8,7 +8,7 @@ thumbnail: "/thumbnails/simple-icon-file-maker.png"
 tags: ["windows", "winui", ".ico", "icon", "developer tool"]
 license: "MIT"
 date_added: "2026-04-08"
-featured: false
+featured: true
 ai_summary: "Turn your images and SVGs into crisp, multi-sized .ico files with zero hassle—perfect for sprucing up your apps and websites in a snap! This tiny tool keeps icon-making simple, fast, and fun."
 ai_features: ["🎨 Drag and drop or paste images directly from clipboard", "🔍 Preview icons at multiple resolutions before saving", "💾 Save your custom .ico files effortlessly"]
 ---

--- a/src/content/tools/smolmoji.md
+++ b/src/content/tools/smolmoji.md
@@ -10,7 +10,7 @@ tags: ["icons", "emoji", "fun", "pixelated"]
 language: "react, typescript"
 license: "MIT"
 date_added: "2026-02-13"
-featured: true
+featured: false
 ai_summary: "Turn your wildest emoji dreams into adorable pixel art with the help of AI — just describe what you want and watch tiny masterpieces appear like magic."
 ai_features: ["🎨 AI-powered pixel art generation from text prompts", "✏️ Edit and customize your creations", "🖼️ Perfect for custom Slack emojis and icons", "🌐 Works right in your browser at smolmoji.com"]
 ---

--- a/src/content/tools/stillness.md
+++ b/src/content/tools/stillness.md
@@ -9,7 +9,7 @@ website_url: "https://ladynaggaga.github.io/Stillness/"
 tags: ["calm", "color", "click", "web"]
 language: "HTML, JS"
 date_added: "2026-02-14"
-featured: true
+featured: false
 ai_summary: "A calming browser coloring book that turns a noisy day into a click and paint mini-retreat, letting you flood regions, doodle with a soft brush, and drift off to ambient chimes while you color."
 ai_features: ["🖌️ Intuitive tools for fill brush gradient eraser and eyedropper", "🧩 Six handcrafted patterns including mandalas florals ocean and zentangle", "🎨 Curated 25 color palette with HSL sliders and dual gradient selector", "💾 Export PNG or SVG and save or resume progress from localStorage"]
 ---

--- a/src/content/tools/textream.md
+++ b/src/content/tools/textream.md
@@ -10,7 +10,7 @@ tags: ["macos", "presentation", "teleprompter", "streaming"]
 language: "Swift"
 license: "MIT"
 date_added: "2026-02-11"
-featured: false
+featured: true
 ai_summary: "A gorgeous macOS teleprompter that literally follows along as you speak — using on-device speech recognition to highlight each word in real-time through a slick Dynamic Island-style overlay that only you can see."
 ai_features: ["🎙️ Real-time word tracking highlights text as you speak with zero cloud latency", "🏝️ Dynamic Island overlay pins elegantly below your MacBook notch", "🔇 Voice-activated mode scrolls when you talk and pauses when you breathe", "📱 Fullscreen mode works on Sidecar iPads for the ultimate presenter setup"]
 ---


### PR DESCRIPTION
## Weekly featured tool refresh

This PR was generated automatically by the scheduled featured-tools workflow.

It refreshes the homepage featured set using:
- thumbnail presence
- recent additions
- GitHub stars
- language/tag diversity
- cooldown history to avoid featuring the same tools every week

Pinned tools remain included until removed from `.github/featured-tools-config.json`.