### PR TITLE
Add author showcase pages

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -11,6 +11,7 @@ const currentPath = Astro.url.pathname;
     <nav class="nav" aria-label="Primary navigation">
       <div class="nav-links">
         <a href="/tools/" class:list={["nav-link", { active: currentPath.startsWith('/tools') }]}>Browse</a>
+        <a href="/authors/" class:list={["nav-link", { active: currentPath.startsWith('/authors') }]}>Authors</a>
         <a href="/favorites/" class:list={["nav-link", { active: currentPath.startsWith('/favorites') }]}>Favorites</a>
         <a href="/submit/" class:list={["nav-link", { active: currentPath === '/submit/' }]}>Submit</a>
         <a href="/about/" class:list={["nav-link", { active: currentPath === '/about/' }]}>About</a>
@@ -36,6 +37,7 @@ const currentPath = Astro.url.pathname;
   <div class="mobile-menu" id="mobile-menu" hidden>
     <div class="container mobile-menu-inner">
       <a href="/tools/" class:list={["mobile-nav-link", { active: currentPath.startsWith('/tools') }]}>Browse</a>
+      <a href="/authors/" class:list={["mobile-nav-link", { active: currentPath.startsWith('/authors') }]}>Authors</a>
       <a href="/favorites/" class:list={["mobile-nav-link", { active: currentPath.startsWith('/favorites') }]}>Favorites</a>
       <a href="/submit/" class:list={["mobile-nav-link", { active: currentPath === '/submit/' }]}>Submit</a>
       <a href="/about/" class:list={["mobile-nav-link", { active: currentPath === '/about/' }]}>About</a>

--- a/src/components/ToolCard.astro
+++ b/src/components/ToolCard.astro
@@ -1,5 +1,6 @@
 ---
 import { getGitHubRepo } from '../lib/github';
+import { getAuthorPath, getAvatarUrl } from '../lib/authors';
 
 interface Props {
   name: string;
@@ -17,6 +18,7 @@ interface Props {
 
 const { name, slug, tagline, author, author_github, tags, language, featured, thumbnail, github_url, stars } = Astro.props;
 const repo = getGitHubRepo(github_url);
+const authorPath = getAuthorPath(author_github);
 
 const langColors: Record<string, string> = {
   'C#': '#178600',
@@ -31,14 +33,15 @@ const langColors: Record<string, string> = {
 const langColor = language ? langColors[language] || '#8b949e' : null;
 ---
 
-<article class="tool-card-shell" data-tool-card data-tool={slug}>
+<article class:list={["tool-card-shell", { featured }]} data-tool-card data-tool={slug}>
   <button class="tool-favorite-btn" data-tool={slug} data-tool-name={name} type="button" aria-pressed="false" aria-label={`Add ${name} to favorites`}>
     <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
       <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z" />
     </svg>
   </button>
 
-  <a href={`/tools/${slug}/`} class:list={["tool-card", { featured }]}>
+  <a href={`/tools/${slug}/`} class="tool-card-link" aria-label={`View ${name}`}></a>
+  <div class:list={["tool-card", { featured }]}>
     <div class="card-thumbnail">
       {thumbnail ? (
         <img
@@ -73,13 +76,13 @@ const langColor = language ? langColors[language] || '#8b949e' : null;
       </div>
       <div class="card-author">
         <img
-          src={`https://avatars.githubusercontent.com/${author_github}?s=24`}
+          src={getAvatarUrl(author_github, 24)}
           alt={author}
           class="author-avatar"
           loading="lazy"
           decoding="async"
         />
-        <span class="author-name" data-author-search={author.toLowerCase()}>{author}</span>
+        <a href={authorPath} class="author-name">{author}</a>
         {typeof stars === 'number' ? (
           <span class="card-stars-count">⭐ {stars.toLocaleString()}</span>
         ) : repo ? (
@@ -94,7 +97,7 @@ const langColor = language ? langColors[language] || '#8b949e' : null;
         ) : null}
       </div>
     </div>
-  </a>
+  </div>
 </article>
 
 <script>
@@ -149,14 +152,6 @@ const langColor = language ? langColors[language] || '#8b949e' : null;
     });
   });
 
-  document.querySelectorAll('.author-name[data-author-search]').forEach(el => {
-    el.addEventListener('click', (e) => {
-      e.preventDefault();
-      e.stopPropagation();
-      window.location.href = `/tools/?q=${encodeURIComponent((el as HTMLElement).dataset.authorSearch!)}`;
-    });
-  });
-
   updateCardFavoriteStates();
   window.addEventListener(FAVORITES_CHANGED_EVENT, updateCardFavoriteStates);
 </script>
@@ -167,6 +162,18 @@ const langColor = language ? langColors[language] || '#8b949e' : null;
     height: 100%;
   }
 
+  .tool-card-link {
+    position: absolute;
+    inset: 0;
+    z-index: 1;
+    border-radius: var(--radius-lg);
+  }
+
+  .tool-card-link:focus-visible {
+    outline: 2px solid var(--color-primary);
+    outline-offset: 4px;
+  }
+
   .tool-card {
     display: flex;
     flex-direction: column;
@@ -175,12 +182,11 @@ const langColor = language ? langColors[language] || '#8b949e' : null;
     border-radius: var(--radius-lg);
     overflow: hidden;
     transition: all 0.3s ease;
-    text-decoration: none;
     color: var(--color-text);
     height: 100%;
   }
 
-  .tool-card:hover {
+  .tool-card-shell:hover .tool-card {
     transform: translateY(-4px);
     border-color: var(--color-primary);
     box-shadow: 0 8px 30px rgba(255, 137, 6, 0.15);
@@ -248,7 +254,7 @@ const langColor = language ? langColors[language] || '#8b949e' : null;
     transition: transform 0.3s ease;
   }
 
-  .tool-card:hover .card-thumbnail img {
+  .tool-card-shell:hover .card-thumbnail img {
     transform: scale(1.05);
   }
 
@@ -338,6 +344,9 @@ const langColor = language ? langColors[language] || '#8b949e' : null;
     margin-top: 0.5rem;
     padding-top: 0.75rem;
     border-top: 1px solid var(--color-border);
+    position: relative;
+    z-index: 2;
+    pointer-events: none;
   }
 
   .author-avatar {
@@ -349,7 +358,8 @@ const langColor = language ? langColors[language] || '#8b949e' : null;
   .author-name {
     font-size: 0.8rem;
     color: var(--color-text-muted);
-    cursor: pointer;
+    text-decoration: none;
+    pointer-events: auto;
   }
 
   .author-name:hover {

--- a/src/lib/__tests__/authors.test.ts
+++ b/src/lib/__tests__/authors.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest';
+import type { ToolEntry } from '../authors';
+import { buildAuthorIntro, buildAuthors, getAuthorPath, getAvatarUrl, normalizeGitHubHandle, slugForTool } from '../authors';
+
+function tool(id: string, data: Partial<ToolEntry['data']> & Pick<ToolEntry['data'], 'name' | 'author' | 'author_github' | 'tags' | 'date_added'>): ToolEntry {
+  return {
+    id,
+    body: '',
+    collection: 'tools',
+    data: {
+      tagline: `${data.name} tagline`,
+      github_url: `https://github.com/${data.author_github}/${id}`,
+      ...data,
+    },
+  } as ToolEntry;
+}
+
+describe('author helpers', () => {
+  it('normalizes GitHub handles for URLs and avatars', () => {
+    expect(normalizeGitHubHandle(' @Shanselman ')).toBe('shanselman');
+    expect(getAuthorPath('Shanselman')).toBe('/authors/shanselman/');
+    expect(getAvatarUrl('@Shanselman', 48)).toBe('https://avatars.githubusercontent.com/shanselman?s=48');
+  });
+
+  it('groups tools case-insensitively and sorts authors by tool count then name', () => {
+    const authors = buildAuthors([
+      tool('one.md', {
+        name: 'One',
+        author: 'Scott Hanselman',
+        author_github: 'Shanselman',
+        tags: ['windows', 'cli'],
+        language: 'C#',
+        date_added: '2026-02-09',
+      }),
+      tool('two.md', {
+        name: 'Two',
+        author: 'Scott Hanselman',
+        author_github: 'shanselman',
+        tags: ['windows'],
+        language: 'PowerShell',
+        date_added: '2026-03-01',
+      }),
+      tool('three.md', {
+        name: 'Three',
+        author: 'Ada',
+        author_github: 'ada',
+        tags: ['web'],
+        language: 'TypeScript',
+        date_added: '2026-01-01',
+      }),
+    ]);
+
+    expect(authors.map(author => author.github)).toEqual(['shanselman', 'ada']);
+    expect(authors[0].toolCount).toBe(2);
+    expect(authors[0].latestTool.data.name).toBe('Two');
+    expect(authors[0].tags).toEqual([
+      { name: 'windows', count: 2 },
+      { name: 'cli', count: 1 },
+    ]);
+    expect(authors[0].languages.map(language => language.name)).toEqual(['C#', 'PowerShell']);
+  });
+
+  it('builds concrete fallback intros from aggregated tool data', () => {
+    const [author] = buildAuthors([
+      tool('timer.md', {
+        name: 'Timer',
+        author: 'Maker',
+        author_github: 'maker',
+        tags: ['presentation', 'web'],
+        language: 'TypeScript',
+        date_added: '2026-01-01',
+      }),
+    ]);
+
+    expect(buildAuthorIntro(author)).toBe('Maker has shared 1 tiny tool here, mostly around presentation and web. The tools span TypeScript.');
+    expect(slugForTool(author.tools[0])).toBe('timer');
+  });
+});

--- a/src/lib/authors.ts
+++ b/src/lib/authors.ts
@@ -1,0 +1,166 @@
+import type { CollectionEntry } from 'astro:content';
+
+export type ToolEntry = CollectionEntry<'tools'>;
+
+export interface CountedValue {
+  name: string;
+  count: number;
+}
+
+export interface AuthorSummary {
+  github: string;
+  name: string;
+  tools: ToolEntry[];
+  toolCount: number;
+  tags: CountedValue[];
+  languages: CountedValue[];
+  latestDateAdded: string;
+  latestTool: ToolEntry;
+}
+
+export interface AuthorProfileSection {
+  title: string;
+  description: string;
+  toolSlugs: string[];
+}
+
+export interface AuthorProfile {
+  github: string;
+  headline: string;
+  intro: string;
+  notes: string[];
+  sections: AuthorProfileSection[];
+}
+
+export const customAuthorProfiles: Record<string, AuthorProfile> = {
+  shanselman: {
+    github: 'shanselman',
+    headline: 'Small Windows comforts, terminal helpers, productivity papercuts, and joyful nonsense.',
+    intro: 'Scott keeps a bench full of tiny utilities: little Windows affordances, command-line helpers, browser glue, speaking timers, health experiments, and a few bits of software that exist because computers should occasionally be silly.',
+    notes: [
+      'A lot of these tools smooth over daily friction: panes, desktops, package updates, certificates, shipping labels.',
+      'Some are intentionally tiny and specific. Toasty is a 229 KB notification CLI; BabySmash is exactly what it sounds like.',
+      'The common thread is practical tinkering: make the rough edge visible, shave it down, share the result.',
+    ],
+    sections: [
+      {
+        title: 'Windows workbench',
+        description: 'Desktop and tray utilities for small Windows annoyances: virtual desktops, peeking at the wallpaper, posture nudges, edge lights, handheld companion controls, and Terminal pane cleanup.',
+        toolSlugs: [
+          'maximize-to-virtual-desktop',
+          'peekdesktop',
+          'posturr-windows',
+          'windows-edge-light',
+          'openclaw-windows-hub',
+          'splitpanefix',
+        ],
+      },
+      {
+        title: 'Terminal and developer helpers',
+        description: 'Tools for package updates, toast notifications, certificate inspection, and focused presentation timing.',
+        toolSlugs: ['winget-tui', 'toasty', 'cert-inspector', 'markwatch'],
+      },
+      {
+        title: 'Useful one-offs and odd joys',
+        description: 'Browser automation, health-data experiments, and keyboard-smashing fun for small kids.',
+        toolSlugs: ['depop-to-pirateship', 'nightscout-cgm-skill', 'babysmash'],
+      },
+    ],
+  },
+};
+
+export function normalizeGitHubHandle(handle: string): string {
+  return handle.trim().replace(/^@+/, '').toLowerCase();
+}
+
+export function getAuthorPath(handle: string): string {
+  return `/authors/${normalizeGitHubHandle(handle)}/`;
+}
+
+export function getAvatarUrl(handle: string, size = 96): string {
+  return `https://avatars.githubusercontent.com/${normalizeGitHubHandle(handle)}?s=${size}`;
+}
+
+export function slugForTool(tool: ToolEntry): string {
+  return tool.id.replace(/\.md$/, '');
+}
+
+export function buildAuthors(tools: ToolEntry[]): AuthorSummary[] {
+  const groups = new Map<string, ToolEntry[]>();
+
+  for (const tool of tools) {
+    const github = normalizeGitHubHandle(tool.data.author_github);
+    if (!github) continue;
+    const group = groups.get(github) || [];
+    group.push(tool);
+    groups.set(github, group);
+  }
+
+  return [...groups.entries()]
+    .map(([github, authorTools]) => buildAuthorSummary(github, authorTools))
+    .sort((a, b) =>
+      b.toolCount - a.toolCount
+      || a.name.localeCompare(b.name)
+      || a.github.localeCompare(b.github)
+    );
+}
+
+export function buildAuthorIntro(author: AuthorSummary): string {
+  const topTags = author.tags.slice(0, 5).map(tag => tag.name);
+  const languages = author.languages.map(language => language.name);
+  const tagText = topTags.length > 0 ? `, mostly around ${formatList(topTags)}` : '';
+  const languageText = languages.length > 0 ? ` The tools span ${formatList(languages)}.` : '';
+
+  return `${author.name} has shared ${author.toolCount} ${pluralize('tiny tool', author.toolCount)} here${tagText}.${languageText}`;
+}
+
+function buildAuthorSummary(github: string, tools: ToolEntry[]): AuthorSummary {
+  const sortedTools = [...tools].sort((a, b) =>
+    b.data.date_added.localeCompare(a.data.date_added)
+    || a.data.name.localeCompare(b.data.name)
+  );
+  const latestTool = sortedTools[0];
+
+  return {
+    github,
+    name: chooseCanonicalName(tools),
+    tools: sortedTools,
+    toolCount: tools.length,
+    tags: countValues(tools.flatMap(tool => tool.data.tags)),
+    languages: countValues(tools.map(tool => tool.data.language).filter((language): language is string => Boolean(language))),
+    latestDateAdded: latestTool.data.date_added,
+    latestTool,
+  };
+}
+
+function chooseCanonicalName(tools: ToolEntry[]): string {
+  return countValues(tools.map(tool => tool.data.author))[0]?.name || tools[0]?.data.author || 'Unknown author';
+}
+
+function countValues(values: string[]): CountedValue[] {
+  const counts = new Map<string, { name: string; count: number }>();
+
+  for (const value of values) {
+    const key = value.trim().toLowerCase();
+    if (!key) continue;
+    const current = counts.get(key);
+    if (current) {
+      current.count++;
+    } else {
+      counts.set(key, { name: value.trim(), count: 1 });
+    }
+  }
+
+  return [...counts.values()].sort((a, b) => b.count - a.count || a.name.localeCompare(b.name));
+}
+
+function pluralize(label: string, count: number): string {
+  return count === 1 ? label : `${label}s`;
+}
+
+function formatList(values: string[]): string {
+  if (values.length === 0) return '';
+  if (values.length === 1) return values[0];
+  if (values.length === 2) return `${values[0]} and ${values[1]}`;
+  return `${values.slice(0, -1).join(', ')}, and ${values[values.length - 1]}`;
+}

--- a/src/pages/authors/[github].astro
+++ b/src/pages/authors/[github].astro
@@ -1,0 +1,469 @@
+---
+import BaseLayout from '../../layouts/BaseLayout.astro';
+import Header from '../../components/Header.astro';
+import Footer from '../../components/Footer.astro';
+import ToolCard from '../../components/ToolCard.astro';
+import { getCollection } from 'astro:content';
+import { buildAuthorIntro, buildAuthors, customAuthorProfiles, getAvatarUrl, slugForTool } from '../../lib/authors';
+import { fetchStarCounts, getGitHubRepo } from '../../lib/github';
+
+export async function getStaticPaths() {
+  const tools = await getCollection('tools');
+  return buildAuthors(tools).map((author) => ({
+    params: { github: author.github },
+  }));
+}
+
+const allTools = await getCollection('tools');
+const authors = buildAuthors(allTools);
+const author = authors.find(item => item.github === Astro.params.github);
+
+if (!author) {
+  throw new Error(`Author not found: ${Astro.params.github}`);
+}
+
+const profile = customAuthorProfiles[author.github];
+const intro = profile?.intro || buildAuthorIntro(author);
+const headline = profile?.headline || `${author.toolCount} ${author.toolCount === 1 ? 'tiny tool' : 'tiny tools'} by ${author.name}`;
+const metaDescription = `${author.name} (@${author.github}) has ${author.toolCount} ${author.toolCount === 1 ? 'tool' : 'tools'} in Tiny Tool Town. ${author.tags.slice(0, 4).map(tag => tag.name).join(', ')}.`;
+
+const repoMap = new Map<string, string>();
+for (const tool of author.tools) {
+  const repo = getGitHubRepo(tool.data.github_url);
+  if (repo) repoMap.set(tool.id, repo);
+}
+const starCounts = await fetchStarCounts([...repoMap.values()]);
+const toolStars = new Map<string, number>();
+for (const [slug, repo] of repoMap) {
+  toolStars.set(slug, starCounts.get(repo) || 0);
+}
+
+const toolsBySlug = new Map(author.tools.map(tool => [slugForTool(tool), tool]));
+const profileSections = profile?.sections
+  .map(section => ({
+    ...section,
+    tools: section.toolSlugs.map(slug => toolsBySlug.get(slug)).filter((tool): tool is typeof author.tools[number] => Boolean(tool)),
+  }))
+  .filter(section => section.tools.length > 0) || [];
+
+function formatDate(value: string) {
+  return new Date(`${value}T00:00:00`).toLocaleDateString('en', {
+    month: 'long',
+    day: 'numeric',
+    year: 'numeric',
+  });
+}
+---
+
+<BaseLayout title={`${author.name} (@${author.github}) - Tiny Tool Town`} description={metaDescription}>
+  <Header />
+
+  <main id="main" class="container">
+    <nav class="breadcrumb">
+      <a href="/">Home</a>
+      <span class="sep">/</span>
+      <a href="/authors/">Authors</a>
+      <span class="sep">/</span>
+      <span class="current">@{author.github}</span>
+    </nav>
+
+    <section class:list={["author-hero", { "custom-hero": Boolean(profile) }]}>
+      <img
+        src={getAvatarUrl(author.github, 240)}
+        alt={author.name}
+        class="author-avatar"
+        width="120"
+        height="120"
+        decoding="async"
+      />
+      <div class="author-hero-copy">
+        <p class="eyebrow">Author showcase</p>
+        <h1>{author.name}</h1>
+        <p class="handle">
+          <a href={`https://github.com/${author.github}`} target="_blank" rel="noopener">@{author.github}</a>
+        </p>
+        <p class="headline">{headline}</p>
+        <p class="intro">{intro}</p>
+        <div class="author-actions">
+          <a href={`https://github.com/${author.github}`} class="btn btn-primary" target="_blank" rel="noopener">GitHub profile</a>
+          <a href="#tools" class="btn btn-secondary">{author.toolCount} {author.toolCount === 1 ? 'tool' : 'tools'}</a>
+        </div>
+      </div>
+    </section>
+
+    {profile && (
+      <section class="profile-notes" aria-label="Workbench notes">
+        {profile.notes.map(note => (
+          <p>{note}</p>
+        ))}
+      </section>
+    )}
+
+    <section class="breakdown" aria-label="Author breakdown">
+      <div class="breakdown-card">
+        <span class="stat-number">{author.toolCount}</span>
+        <span class="stat-label">{author.toolCount === 1 ? 'tool' : 'tools'} listed</span>
+      </div>
+      <div class="breakdown-card">
+        <span class="stat-number">{author.tags.length}</span>
+        <span class="stat-label">{author.tags.length === 1 ? 'tag' : 'tags'} covered</span>
+      </div>
+      <div class="breakdown-card">
+        <span class="stat-number">{author.languages.length || '–'}</span>
+        <span class="stat-label">{author.languages.length === 1 ? 'language' : 'languages'}</span>
+      </div>
+      <div class="breakdown-card">
+        <span class="stat-number">{formatDate(author.latestDateAdded)}</span>
+        <span class="stat-label">latest addition</span>
+      </div>
+    </section>
+
+    <section class="terms-section">
+      <div>
+        <h2>Tags</h2>
+        <div class="term-list">
+          {author.tags.map(tag => (
+            <a href={`/tools/?tag=${tag.name.toLowerCase()}`} class="term">{tag.name} <span>{tag.count}</span></a>
+          ))}
+        </div>
+      </div>
+      {author.languages.length > 0 && (
+        <div>
+          <h2>Languages</h2>
+          <div class="term-list">
+            {author.languages.map(language => (
+              <span class="term">{language.name} <span>{language.count}</span></span>
+            ))}
+          </div>
+        </div>
+      )}
+    </section>
+
+    {profileSections.length > 0 && (
+      <section class="showcase-sections" aria-label="Featured groups">
+        <div class="section-header">
+          <h2>Workbench shelves</h2>
+          <p>Grouped by what the tools actually do.</p>
+        </div>
+        {profileSections.map(section => (
+          <section class="showcase-section">
+            <div class="showcase-copy">
+              <h3>{section.title}</h3>
+              <p>{section.description}</p>
+            </div>
+            <div class="compact-tool-list">
+              {section.tools.map(tool => (
+                <a href={`/tools/${slugForTool(tool)}/`} class="compact-tool">
+                  <strong>{tool.data.name}</strong>
+                  <span>{tool.data.tagline}</span>
+                </a>
+              ))}
+            </div>
+          </section>
+        ))}
+      </section>
+    )}
+
+    <section class="tools-section" id="tools">
+      <div class="section-header">
+        <h2>{profile ? 'Everything on the bench' : `Tools by ${author.name}`}</h2>
+        <p>Only tools submitted under @{author.github}.</p>
+      </div>
+      <div class="tool-grid">
+        {author.tools.map(tool => (
+          <ToolCard
+            name={tool.data.name}
+            slug={slugForTool(tool)}
+            tagline={tool.data.tagline}
+            author={tool.data.author}
+            author_github={tool.data.author_github}
+            tags={tool.data.tags}
+            language={tool.data.language}
+            featured={tool.data.featured}
+            thumbnail={tool.data.thumbnail}
+            github_url={tool.data.github_url}
+            stars={toolStars.get(tool.id) ?? undefined}
+          />
+        ))}
+      </div>
+    </section>
+  </main>
+
+  <Footer />
+</BaseLayout>
+
+<style>
+  .breadcrumb {
+    display: flex;
+    gap: 0.5rem;
+    font-size: 0.9rem;
+    color: var(--color-text-muted);
+    padding-top: 1.5rem;
+    margin-bottom: 2rem;
+  }
+
+  .breadcrumb a {
+    color: var(--color-text-muted);
+  }
+
+  .breadcrumb a:hover {
+    color: var(--color-primary);
+  }
+
+  .sep { opacity: 0.4; }
+  .current { color: var(--color-text); }
+
+  .author-hero {
+    display: grid;
+    grid-template-columns: auto 1fr;
+    gap: 2rem;
+    align-items: start;
+    padding: 2rem;
+    background: var(--color-bg-card);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-lg);
+    margin-bottom: 1.5rem;
+  }
+
+  .custom-hero {
+    background:
+      radial-gradient(circle at top right, rgba(255, 137, 6, 0.16), transparent 32rem),
+      linear-gradient(135deg, rgba(61, 169, 252, 0.08), rgba(242, 95, 76, 0.05)),
+      var(--color-bg-card);
+  }
+
+  .author-avatar {
+    width: 120px;
+    height: 120px;
+    border-radius: 28px;
+    border: 1px solid var(--color-border);
+  }
+
+  .eyebrow {
+    color: var(--color-primary);
+    font-weight: 800;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    font-size: 0.8rem;
+    margin-bottom: 0.5rem;
+  }
+
+  .author-hero h1 {
+    font-size: clamp(2.4rem, 7vw, 4.5rem);
+    line-height: 0.95;
+    font-weight: 900;
+    margin-bottom: 0.4rem;
+  }
+
+  .handle a {
+    color: var(--color-accent);
+    font-weight: 700;
+    text-decoration: none;
+  }
+
+  .headline {
+    font-size: 1.25rem;
+    color: var(--color-text);
+    line-height: 1.5;
+    margin: 1.25rem 0 0.75rem;
+    max-width: 780px;
+  }
+
+  .intro {
+    color: var(--color-text-muted);
+    line-height: 1.8;
+    max-width: 780px;
+  }
+
+  .author-actions {
+    display: flex;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+    margin-top: 1.5rem;
+  }
+
+  .profile-notes {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 1rem;
+    margin-bottom: 1.5rem;
+  }
+
+  .profile-notes p,
+  .breakdown-card,
+  .terms-section,
+  .showcase-section {
+    background: var(--color-bg-card);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-lg);
+  }
+
+  .profile-notes p {
+    padding: 1.25rem;
+    color: var(--color-text-muted);
+    line-height: 1.7;
+  }
+
+  .breakdown {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: 1rem;
+    margin-bottom: 1.5rem;
+  }
+
+  .breakdown-card {
+    padding: 1.25rem;
+  }
+
+  .stat-number {
+    display: block;
+    font-size: 1.5rem;
+    font-weight: 900;
+    color: var(--color-primary);
+    line-height: 1.2;
+  }
+
+  .stat-label {
+    display: block;
+    color: var(--color-text-muted);
+    font-size: 0.9rem;
+    margin-top: 0.25rem;
+  }
+
+  .terms-section {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 1.5rem;
+    padding: 1.5rem;
+    margin-bottom: 2rem;
+  }
+
+  .terms-section h2 {
+    font-size: 1rem;
+    margin-bottom: 0.75rem;
+  }
+
+  .term-list {
+    display: flex;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+  }
+
+  .term {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    padding: 0.35rem 0.75rem;
+    background: var(--color-tag-bg);
+    color: var(--color-tag-text);
+    border-radius: 999px;
+    font-size: 0.85rem;
+    font-weight: 600;
+    text-decoration: none;
+  }
+
+  .term span {
+    opacity: 0.7;
+  }
+
+  .showcase-sections,
+  .tools-section {
+    margin-bottom: 3rem;
+  }
+
+  .section-header {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 1rem;
+    margin-bottom: 1rem;
+  }
+
+  .section-header h2 {
+    font-size: 1.5rem;
+    font-weight: 800;
+  }
+
+  .section-header p,
+  .showcase-copy p {
+    color: var(--color-text-muted);
+  }
+
+  .showcase-section {
+    display: grid;
+    grid-template-columns: minmax(220px, 0.8fr) 1.6fr;
+    gap: 1.25rem;
+    padding: 1.25rem;
+    margin-bottom: 1rem;
+  }
+
+  .showcase-copy h3 {
+    font-size: 1.15rem;
+    margin-bottom: 0.5rem;
+  }
+
+  .showcase-copy p {
+    line-height: 1.6;
+  }
+
+  .compact-tool-list {
+    display: grid;
+    gap: 0.75rem;
+  }
+
+  .compact-tool {
+    display: grid;
+    gap: 0.2rem;
+    padding: 0.85rem 1rem;
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius);
+    text-decoration: none;
+    color: var(--color-text);
+    background: rgba(255, 255, 255, 0.03);
+  }
+
+  .compact-tool:hover {
+    border-color: var(--color-primary);
+  }
+
+  .compact-tool span {
+    color: var(--color-text-muted);
+    font-size: 0.9rem;
+  }
+
+  .tool-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+    gap: 1.5rem;
+  }
+
+  @media (max-width: 820px) {
+    .author-hero,
+    .showcase-section,
+    .terms-section {
+      grid-template-columns: 1fr;
+    }
+
+    .profile-notes,
+    .breakdown {
+      grid-template-columns: repeat(2, 1fr);
+    }
+  }
+
+  @media (max-width: 560px) {
+    .author-hero {
+      padding: 1.25rem;
+    }
+
+    .profile-notes,
+    .breakdown {
+      grid-template-columns: 1fr;
+    }
+
+    .author-avatar {
+      width: 88px;
+      height: 88px;
+      border-radius: 22px;
+    }
+  }
+</style>

--- a/src/pages/authors/index.astro
+++ b/src/pages/authors/index.astro
@@ -1,0 +1,264 @@
+---
+import BaseLayout from '../../layouts/BaseLayout.astro';
+import Header from '../../components/Header.astro';
+import Footer from '../../components/Footer.astro';
+import { getCollection } from 'astro:content';
+import { buildAuthors, getAvatarUrl } from '../../lib/authors';
+
+const tools = await getCollection('tools');
+const authors = buildAuthors(tools);
+const totalTools = authors.reduce((sum, author) => sum + author.toolCount, 0);
+
+function formatDate(value: string) {
+  return new Date(`${value}T00:00:00`).toLocaleDateString('en', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  });
+}
+---
+
+<BaseLayout title="Authors - Tiny Tool Town" description="Meet the makers behind the tiny open source tools in Tiny Tool Town.">
+  <Header />
+
+  <main id="main" class="container">
+    <section class="authors-hero">
+      <p class="eyebrow">Makers in town</p>
+      <h1>Author directory</h1>
+      <p class="hero-copy">
+        Real pages for the people building Tiny Tool Town: {authors.length} authors and {totalTools} tiny tools.
+      </p>
+    </section>
+
+    <div class="authors-filter">
+      <svg class="search-icon" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.35-4.35"/></svg>
+      <label for="author-search" class="visually-hidden">Search authors</label>
+      <input id="author-search" type="text" class="search-input" placeholder="Search authors, handles, tags, languages..." autocomplete="off" />
+    </div>
+
+    <section class="authors-grid" id="authors-grid" aria-label="Authors">
+      {authors.map(author => (
+        <article
+          class="author-card"
+          data-author-card
+          data-name={author.name.toLowerCase()}
+          data-github={author.github}
+          data-tags={author.tags.map(tag => tag.name.toLowerCase()).join(',')}
+          data-languages={author.languages.map(language => language.name.toLowerCase()).join(',')}
+        >
+          <a href={`/authors/${author.github}/`} class="author-card-link">
+            <img
+              src={getAvatarUrl(author.github, 128)}
+              alt={author.name}
+              class="author-avatar"
+              loading="lazy"
+              decoding="async"
+              width="64"
+              height="64"
+            />
+            <div class="author-card-body">
+              <div class="author-card-heading">
+                <h2>{author.name}</h2>
+                <span>@{author.github}</span>
+              </div>
+              <p class="tool-count">{author.toolCount} {author.toolCount === 1 ? 'tool' : 'tools'}</p>
+              <div class="top-tags">
+                {author.tags.slice(0, 4).map(tag => (
+                  <span class="tag">{tag.name}</span>
+                ))}
+              </div>
+              <p class="latest-tool">
+                Latest: <strong>{author.latestTool.data.name}</strong>
+                <span>added {formatDate(author.latestDateAdded)}</span>
+              </p>
+            </div>
+          </a>
+        </article>
+      ))}
+    </section>
+
+    <div id="no-authors" class="no-results" hidden>
+      <p>No authors found. Try a different search.</p>
+    </div>
+  </main>
+
+  <Footer />
+</BaseLayout>
+
+<script>
+  const search = document.getElementById('author-search') as HTMLInputElement | null;
+  const cards = document.querySelectorAll<HTMLElement>('[data-author-card]');
+  const noAuthors = document.getElementById('no-authors');
+
+  function filterAuthors(): void {
+    const query = search?.value.toLowerCase().trim() || '';
+    let visible = 0;
+
+    cards.forEach(card => {
+      const haystack = [
+        card.dataset.name,
+        card.dataset.github,
+        card.dataset.tags,
+        card.dataset.languages,
+      ].join(' ');
+      const matches = !query || haystack.includes(query);
+      card.hidden = !matches;
+      if (matches) visible++;
+    });
+
+    if (noAuthors) noAuthors.hidden = visible !== 0;
+  }
+
+  search?.addEventListener('input', filterAuthors);
+</script>
+
+<style>
+  .authors-hero {
+    padding: 3rem 0 1.5rem;
+    max-width: 760px;
+  }
+
+  .eyebrow {
+    color: var(--color-primary);
+    font-weight: 800;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    font-size: 0.8rem;
+    margin-bottom: 0.5rem;
+  }
+
+  .authors-hero h1 {
+    font-size: clamp(2.25rem, 6vw, 4rem);
+    line-height: 1;
+    font-weight: 900;
+    margin-bottom: 1rem;
+  }
+
+  .hero-copy {
+    color: var(--color-text-muted);
+    font-size: 1.15rem;
+    line-height: 1.7;
+  }
+
+  .authors-filter {
+    position: relative;
+    margin-bottom: 1.5rem;
+  }
+
+  .search-icon {
+    position: absolute;
+    left: 1rem;
+    top: 50%;
+    transform: translateY(-50%);
+    color: var(--color-text-muted);
+    pointer-events: none;
+  }
+
+  .search-input {
+    width: 100%;
+    padding: 0.85rem 1rem 0.85rem 2.75rem;
+    background: var(--color-bg-card);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius);
+    color: var(--color-text);
+    font-size: 1rem;
+    font-family: inherit;
+  }
+
+  .search-input:focus {
+    outline: none;
+    border-color: var(--color-primary);
+  }
+
+  .authors-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+    gap: 1.25rem;
+    margin-bottom: 3rem;
+  }
+
+  .author-card-link {
+    display: flex;
+    gap: 1rem;
+    height: 100%;
+    padding: 1.25rem;
+    background: var(--color-bg-card);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-lg);
+    color: var(--color-text);
+    text-decoration: none;
+    transition: transform 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+  }
+
+  .author-card-link:hover,
+  .author-card-link:focus-visible {
+    transform: translateY(-3px);
+    border-color: var(--color-primary);
+    box-shadow: 0 8px 30px rgba(255, 137, 6, 0.12);
+    outline: none;
+  }
+
+  .author-avatar {
+    width: 64px;
+    height: 64px;
+    border-radius: 50%;
+    border: 1px solid var(--color-border);
+    flex-shrink: 0;
+  }
+
+  .author-card-body {
+    min-width: 0;
+  }
+
+  .author-card-heading {
+    display: grid;
+    gap: 0.15rem;
+    margin-bottom: 0.5rem;
+  }
+
+  .author-card-heading h2 {
+    font-size: 1.1rem;
+    line-height: 1.2;
+  }
+
+  .author-card-heading span,
+  .tool-count,
+  .latest-tool {
+    color: var(--color-text-muted);
+    font-size: 0.9rem;
+  }
+
+  .tool-count {
+    margin-bottom: 0.75rem;
+  }
+
+  .top-tags {
+    display: flex;
+    gap: 0.375rem;
+    flex-wrap: wrap;
+    margin-bottom: 0.85rem;
+  }
+
+  .tag {
+    font-size: 0.75rem;
+    padding: 0.2rem 0.6rem;
+    background: var(--color-tag-bg);
+    color: var(--color-tag-text);
+    border-radius: 50px;
+    font-weight: 500;
+  }
+
+  .latest-tool {
+    line-height: 1.5;
+  }
+
+  .latest-tool span {
+    display: block;
+  }
+
+  .no-results {
+    text-align: center;
+    padding: 3rem;
+    color: var(--color-text-muted);
+  }
+</style>

--- a/src/pages/tools/[slug].astro
+++ b/src/pages/tools/[slug].astro
@@ -4,6 +4,7 @@ import Header from '../../components/Header.astro';
 import Footer from '../../components/Footer.astro';
 import { getCollection, render } from 'astro:content';
 import { getGitHubRepo } from '../../lib/github';
+import { getAuthorPath, getAvatarUrl } from '../../lib/authors';
 import { existsSync } from 'node:fs';
 import { join } from 'node:path';
 
@@ -19,6 +20,7 @@ const { tool } = Astro.props;
 const { Content } = await render(tool);
 const repo = getGitHubRepo(tool.data.github_url);
 const slug = tool.id.replace(/\.md$/, '');
+const authorPath = getAuthorPath(tool.data.author_github);
 
 function stripMarkdown(markdown: string) {
   return markdown
@@ -84,14 +86,14 @@ const ogImage = hasSocialCard ? `/social/${slug}.png` : undefined;
           <div class="tool-meta">
             <div class="tool-author">
               <img
-                src={`https://avatars.githubusercontent.com/${tool.data.author_github}?s=40`}
+                src={getAvatarUrl(tool.data.author_github, 40)}
                 alt={tool.data.author}
                 class="author-avatar"
                 loading="lazy"
                 decoding="async"
               />
               <div>
-                <a href={`/tools/?q=${encodeURIComponent(tool.data.author.toLowerCase())}`} class="author-name">{tool.data.author}</a>
+                <a href={authorPath} class="author-name">{tool.data.author}</a>
               </div>
             </div>
 


### PR DESCRIPTION
## Summary
- Add first-class /authors/ directory and /authors/[github]/ showcase pages generated from existing tool frontmatter
- Add author aggregation helpers with tests, including normalized GitHub handles, counts, tags/languages, latest tool, avatars, and Scott dogfood profile content
- Update tool card/detail author links and header navigation to point at author pages

## Validation
- npm test
- npm run build