### PR TITLE
Add author feeds and release links

### DIFF
--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -10,6 +10,8 @@ const tools = defineCollection({
     author_github: z.string(),
     github_url: z.string().url(),
     website_url: z.string().url().optional(),
+    release_url: z.string().url().optional(),
+    download_url: z.string().url().optional(),
     thumbnail_source: z.string().url().optional(),
     thumbnail: z.string().optional(),
     tags: z.array(z.string()),

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -3,6 +3,8 @@ interface Props {
   title?: string;
   description?: string;
   ogImage?: string;
+  rssHref?: string;
+  rssTitle?: string;
   theme?: string;
 }
 
@@ -10,6 +12,8 @@ const {
   title = "Tiny Tool Town 🏘️",
   description = "A delightful showcase for free, fun & open source tiny tools. Stupid-delightful software made with love.",
   ogImage = "/og-image.png",
+  rssHref,
+  rssTitle,
   theme
 } = Astro.props;
 
@@ -62,6 +66,7 @@ const ogImageType = ogImageExt === 'jpg' || ogImageExt === 'jpeg'
 
   <!-- RSS Feed -->
   <link rel="alternate" type="application/rss+xml" title="Tiny Tool Town" href="/rss.xml" />
+  {rssHref && <link rel="alternate" type="application/rss+xml" title={rssTitle || title} href={rssHref} />}
 
   <!-- Prevent theme flash: apply saved/tool theme before paint -->
   <script is:inline define:vars={{ theme }}>

--- a/src/pages/authors/[github].astro
+++ b/src/pages/authors/[github].astro
@@ -26,6 +26,7 @@ const profile = customAuthorProfiles[author.github];
 const intro = profile?.intro || buildAuthorIntro(author);
 const headline = profile?.headline || `${author.toolCount} ${author.toolCount === 1 ? 'tiny tool' : 'tiny tools'} by ${author.name}`;
 const metaDescription = `${author.name} (@${author.github}) has ${author.toolCount} ${author.toolCount === 1 ? 'tool' : 'tools'} in Tiny Tool Town. ${author.tags.slice(0, 4).map(tag => tag.name).join(', ')}.`;
+const authorFeedPath = `/rss/authors/${author.github}.xml`;
 
 const repoMap = new Map<string, string>();
 for (const tool of author.tools) {
@@ -55,7 +56,12 @@ function formatDate(value: string) {
 }
 ---
 
-<BaseLayout title={`${author.name} (@${author.github}) - Tiny Tool Town`} description={metaDescription}>
+<BaseLayout
+  title={`${author.name} (@${author.github}) - Tiny Tool Town`}
+  description={metaDescription}
+  rssHref={authorFeedPath}
+  rssTitle={`${author.name}'s Tiny Tool Town tools`}
+>
   <Header />
 
   <main id="main" class="container">
@@ -86,6 +92,7 @@ function formatDate(value: string) {
         <p class="intro">{intro}</p>
         <div class="author-actions">
           <a href={`https://github.com/${author.github}`} class="btn btn-primary" target="_blank" rel="noopener">GitHub profile</a>
+          <a href={authorFeedPath} class="btn btn-secondary">RSS feed</a>
           <a href="#tools" class="btn btn-secondary">{author.toolCount} {author.toolCount === 1 ? 'tool' : 'tools'}</a>
         </div>
       </div>

--- a/src/pages/rss/authors/[github].xml.ts
+++ b/src/pages/rss/authors/[github].xml.ts
@@ -1,0 +1,51 @@
+import rss from '@astrojs/rss';
+import { getCollection } from 'astro:content';
+import type { APIContext } from 'astro';
+import { buildAuthorIntro, buildAuthors, slugForTool, type AuthorSummary } from '../../../lib/authors';
+
+export async function getStaticPaths() {
+  const tools = await getCollection('tools');
+  return buildAuthors(tools).map((author) => ({
+    params: { github: author.github },
+    props: { author },
+  }));
+}
+
+export async function GET(context: APIContext) {
+  const author = context.props.author as AuthorSummary;
+  const site = context.site!;
+  const feedUrl = new URL(`/rss/authors/${author.github}.xml`, site).href;
+
+  return rss({
+    title: `Tiny Tool Town — ${author.name}`,
+    description: buildAuthorIntro(author),
+    site,
+    xmlns: { atom: 'http://www.w3.org/2005/Atom' },
+    customData: [
+      `<language>en-us</language>`,
+      `<atom:link href="${feedUrl}" rel="self" type="application/rss+xml" />`,
+    ].join(''),
+    items: author.tools.map((tool) => {
+      const slug = slugForTool(tool);
+      const parts: string[] = [];
+
+      parts.push(tool.data.tagline);
+      parts.push('');
+      parts.push(`By ${tool.data.author} (@${tool.data.author_github})`);
+      if (tool.data.language) parts.push(`Language: ${tool.data.language}`);
+      if (tool.data.license) parts.push(`License: ${tool.data.license}`);
+      parts.push(`GitHub: ${tool.data.github_url}`);
+      if (tool.data.website_url) parts.push(`Website: ${tool.data.website_url}`);
+      if (tool.data.release_url) parts.push(`Release: ${tool.data.release_url}`);
+      if (tool.data.download_url) parts.push(`Download: ${tool.data.download_url}`);
+
+      return {
+        title: tool.data.name,
+        pubDate: new Date(tool.data.date_added),
+        description: parts.join('\n'),
+        link: new URL(`/tools/${slug}/`, site).href,
+        categories: tool.data.tags,
+      };
+    }),
+  });
+}

--- a/src/pages/tools/[slug].astro
+++ b/src/pages/tools/[slug].astro
@@ -21,6 +21,9 @@ const { Content } = await render(tool);
 const repo = getGitHubRepo(tool.data.github_url);
 const slug = tool.id.replace(/\.md$/, '');
 const authorPath = getAuthorPath(tool.data.author_github);
+const explicitReleaseUrl = tool.data.download_url || tool.data.release_url;
+const releasesUrl = explicitReleaseUrl || (repo ? `https://github.com/${repo}/releases` : undefined);
+const releasesLabel = tool.data.download_url ? 'Download' : tool.data.release_url ? 'Latest release' : 'Releases';
 
 function stripMarkdown(markdown: string) {
   return markdown
@@ -130,6 +133,11 @@ const ogImage = hasSocialCard ? `/social/${slug}.png` : undefined;
               <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/></svg>
               View on GitHub
             </a>
+            {releasesUrl && (
+              <a href={releasesUrl} class="btn btn-secondary" target="_blank" rel="noopener">
+                ⬇️ {releasesLabel}
+              </a>
+            )}
             {tool.data.website_url && (
               <a href={tool.data.website_url} class="btn btn-secondary" target="_blank" rel="noopener">
                 🌐 Website


### PR DESCRIPTION
## Summary
- add per-author RSS feeds at /rss/authors/{github}.xml and advertise them on author pages
- add optional release_url/download_url frontmatter support
- add a grounded Releases/Download action on tool detail pages without hitting the GitHub API at build time

## Verification
- npm test
- npm run build
- confirmed dist/rss/authors/shanselman.xml is generated
- confirmed /authors/shanselman/ advertises its author RSS feed
- confirmed tool detail pages show a Releases action for GitHub repos

## Notes
- Copilot's PR 2 run stalled before making changes, so Tony completed this small focused PR directly.
- Future polish: real author social cards and screenshot/content review for weak tool thumbnails.