### PR TITLE
Add customizable author pages

### DIFF
--- a/.github/ISSUE_TEMPLATE/customize-author.yml
+++ b/.github/ISSUE_TEMPLATE/customize-author.yml
@@ -1,0 +1,88 @@
+name: 👤 Customize an Author Page
+description: Claim or update your Tiny Tool Town maker page.
+title: "[Author] @"
+labels: ["author-page"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## Customize your Tiny Tool Town author page 👤
+
+        Everyone with an accepted tool already gets an automatic page at:
+
+        `https://www.tinytooltown.com/authors/YOUR-GITHUB-USERNAME/`
+
+        Use this form if you want to add a bio, headline, links, notes, or featured groups of tools.
+        For safety, requests should come from the same GitHub account as the author page you're claiming.
+
+  - type: input
+    id: github
+    attributes:
+      label: GitHub username for this author page
+      description: This should match the GitHub username used on your Tiny Tool Town tool submissions.
+      placeholder: "e.g., janedev"
+    validations:
+      required: true
+
+  - type: input
+    id: name
+    attributes:
+      label: Display name
+      placeholder: "e.g., Jane Developer"
+
+  - type: input
+    id: headline
+    attributes:
+      label: Short headline
+      description: One sentence that describes the kind of tiny tools you make.
+      placeholder: "Tiny CLI tools, weird browser experiments, and delightful automation."
+
+  - type: textarea
+    id: bio
+    attributes:
+      label: Bio / intro
+      description: A short paragraph for the top of your author page.
+      placeholder: "I make small tools that scratch very specific itches..."
+
+  - type: input
+    id: website_url
+    attributes:
+      label: Website URL (optional)
+      placeholder: "https://example.com"
+
+  - type: textarea
+    id: links
+    attributes:
+      label: Other links (optional)
+      description: One per line, in the format `Label - https://example.com`.
+      placeholder: |
+        Blog - https://example.com/blog
+        Mastodon - https://mastodon.social/@janedev
+
+  - type: textarea
+    id: notes
+    attributes:
+      label: Notes or highlights (optional)
+      description: Short bullets about your workbench, style, or what people should notice.
+      placeholder: |
+        - I like tiny tools that do one thing well.
+        - Most of my projects are weekend experiments.
+
+  - type: textarea
+    id: featured_groups
+    attributes:
+      label: Featured tool groups (optional)
+      description: If you have several tools, tell us how you want them grouped. Include existing Tiny Tool Town tool slugs when you know them.
+      placeholder: |
+        Terminal helpers: my-cli-tool, log-wrangler
+        Browser experiments: bookmarklet-lab, tab-tamer
+
+  - type: checkboxes
+    id: confirm
+    attributes:
+      label: Checklist
+      options:
+        - label: I am requesting changes for my own GitHub author page, or I can explain why I am authorized to request them.
+          required: true
+        - label: I understand maintainers may edit for length, clarity, and site fit.
+          required: true

--- a/.github/ISSUE_TEMPLATE/submit-tool.yml
+++ b/.github/ISSUE_TEMPLATE/submit-tool.yml
@@ -9,6 +9,11 @@ body:
         ## Welcome to Tiny Tool Town! 🏘️
         Fill out this form and we'll review your tool. Once approved, it'll show up on the site automatically!
 
+        Your GitHub username also creates your author page automatically:
+        `https://www.tinytooltown.com/authors/YOUR-GITHUB-USERNAME/`
+
+        After your tool is accepted, you can use the **Customize an Author Page** issue form if you want to add a bio, links, or featured groups of your tools.
+
   - type: input
     id: name
     attributes:

--- a/.github/workflows/batch-approve.yml
+++ b/.github/workflows/batch-approve.yml
@@ -354,12 +354,13 @@ jobs:
                   .slice(0, 5);
 
                 const today = new Date().toISOString().split('T')[0];
+                const cleanAuthorGithub = sanitize(author_github).replace(/[^a-zA-Z0-9_-]/g, '').toLowerCase();
                 const lines = [
                   '---',
                   `name: ${yamlStr(name)}`,
                   `tagline: ${yamlStr(tagline)}`,
                   `author: ${yamlStr(author)}`,
-                  `author_github: "${sanitize(author_github).replace(/[^a-zA-Z0-9_-]/g, '')}"`,
+                  `author_github: "${cleanAuthorGithub}"`,
                   `github_url: ${yamlStr(github_url)}`,
                 ];
                 if (website_url_clean) {
@@ -525,6 +526,7 @@ jobs:
                   issueNumber: issue.number,
                   name: sanitize(name),
                   slug,
+                  authorGithub: cleanAuthorGithub,
                 });
                 if (repoKey) existingRepos.set(repoKey, slug);
                 console.log(`Prepared #${issue.number}: ${name}`);
@@ -601,7 +603,7 @@ jobs:
                   owner,
                   repo,
                   issue_number: item.issueNumber,
-                  body: `🏘️ **Welcome to Tiny Tool Town!**\n\n**${item.name}** has been added and will be live on [tinytooltown.com](https://www.tinytooltown.com/tools/${item.slug}/) once the site rebuilds.`,
+                  body: `🏘️ **Welcome to Tiny Tool Town!**\n\n**${item.name}** has been added and will be live once the site rebuilds:\n\n- Tool page: https://www.tinytooltown.com/tools/${item.slug}/\n- Author page: https://www.tinytooltown.com/authors/${item.authorGithub}/\n- Author RSS feed: https://www.tinytooltown.com/rss/authors/${item.authorGithub}.xml\n\nWant to customize your author page? Open the **Customize an Author Page** issue form: https://github.com/shanselman/TinyToolTown/issues/new?template=customize-author.yml&title=${encodeURIComponent(`[Author] @${item.authorGithub}`)}`,
                 });
                 await github.rest.issues.update({
                   owner,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,6 +26,52 @@ To qualify, a tool should be:
 Each repository can be listed once — duplicate submissions of an already-listed
 repo are detected automatically and won't create a second page.
 
+### Author pages
+
+Every accepted tool automatically creates or updates an author page based on the
+`author_github` value in the tool submission:
+
+```text
+https://www.tinytooltown.com/authors/YOUR-GITHUB-USERNAME/
+```
+
+Author pages collect all tools for that GitHub handle, plus tags, languages,
+latest additions, GitHub avatar, and an author-specific RSS feed.
+
+Authors can customize their page in two ways:
+
+- Open a [Customize an Author Page issue](https://github.com/shanselman/TinyToolTown/issues/new?template=customize-author.yml)
+  with the bio, headline, links, notes, or featured groups they want.
+- Open a PR adding `src/content/authors/YOUR-GITHUB-USERNAME.md`.
+
+For safety, author-page customization requests should come from the matching
+GitHub account, or explain why the requester is authorized to make the change.
+
+Example author profile:
+
+```markdown
+---
+github: "janedev"
+name: "Jane Developer"
+headline: "Tiny CLI tools, weird browser experiments, and delightful automation."
+website_url: "https://janedev.example"
+links:
+  - label: "Blog"
+    url: "https://janedev.example/blog"
+notes:
+  - "I like tiny tools that do one thing well."
+sections:
+  - title: "Terminal helpers"
+    description: "Small command-line tools for daily development papercuts."
+    toolSlugs:
+      - "my-cli-tool"
+---
+I make small tools that scratch very specific itches.
+```
+
+The profile file customizes the author page, but the tool list remains generated
+from accepted Tiny Tool Town submissions.
+
 ## Improving the Site
 
 This is an [Astro](https://astro.build) static site.
@@ -66,6 +112,7 @@ CI (`.github/workflows/ci.yml`) runs the same three commands on every PR.
 ### Project layout
 
 - `src/content/tools/*.md` — one markdown file per tool. Schema in `src/content.config.ts`.
+- `src/content/authors/*.md` — optional author-page customizations. Author pages still exist automatically without these files.
 - `src/pages/`, `src/components/`, `src/layouts/` — Astro pages, components, and layouts.
 - `src/lib/` — shared helpers (and `__tests__/` for unit tests).
 - `scripts/` — Node maintenance scripts (thumbnails, stars, social cards, the

--- a/README.md
+++ b/README.md
@@ -12,6 +12,14 @@ Tiny Tool Town is a community-driven directory of small, delightful, open-source
 
 ## Submit Your Tool
 
+Every accepted tool also creates an **author page** automatically. If your GitHub username is `your-username`, your page will be:
+
+```text
+https://www.tinytooltown.com/authors/your-username/
+```
+
+That page collects all of your Tiny Tool Town tools, your GitHub avatar, tags, languages, latest additions, and a personal RSS feed.
+
 ### Option 1: GitHub Issue (Easy)
 1. [Open a new issue](https://github.com/shanselman/TinyToolTown/issues/new?template=submit-tool.yml)
 2. Fill out the form
@@ -44,6 +52,44 @@ featured: false
 A few sentences about your tool. What does it do?
 Why did you build it? Why is it delightful?
 ```
+
+## Author Pages
+
+Author pages are generated from the `author_github` value on each tool. You do **not** need to create a separate author file to get a page — submit one accepted tool and your author page exists automatically.
+
+Want to customize it? You have two options:
+
+### Option 1: Author Page Issue
+
+Open a [Customize an Author Page issue](https://github.com/shanselman/TinyToolTown/issues/new?template=customize-author.yml) and tell us what bio, headline, links, notes, or featured tool groups you want.
+
+For safety, the request should come from the same GitHub account as the author page being claimed.
+
+### Option 2: Pull Request
+
+Add `src/content/authors/your-username.md`:
+
+```markdown
+---
+github: "your-username"
+name: "Your Name"
+headline: "Tiny CLI tools, weird browser experiments, and delightful automation."
+website_url: "https://example.com"
+links:
+  - label: "Blog"
+    url: "https://example.com/blog"
+notes:
+  - "I like tiny tools that do one thing well."
+sections:
+  - title: "Terminal helpers"
+    description: "Small command-line tools for daily development papercuts."
+    toolSlugs:
+      - "your-tool-slug"
+---
+I make small tools that scratch very specific itches.
+```
+
+The generated page will still list all tools submitted under your GitHub username. Your author file only customizes the intro, links, notes, and optional featured groups.
 
 ## What makes a good Tiny Tool?
 

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -25,4 +25,25 @@ const tools = defineCollection({
   }),
 });
 
-export const collections = { tools };
+const authors = defineCollection({
+  loader: glob({ pattern: '**/*.md', base: './src/content/authors' }),
+  schema: z.object({
+    github: z.string().optional(),
+    name: z.string().optional(),
+    headline: z.string().optional(),
+    intro: z.string().optional(),
+    website_url: z.string().url().optional(),
+    links: z.array(z.object({
+      label: z.string(),
+      url: z.string().url(),
+    })).optional(),
+    notes: z.array(z.string()).optional(),
+    sections: z.array(z.object({
+      title: z.string(),
+      description: z.string(),
+      toolSlugs: z.array(z.string()),
+    })).optional(),
+  }),
+});
+
+export const collections = { tools, authors };

--- a/src/content/authors/shanselman.md
+++ b/src/content/authors/shanselman.md
@@ -1,0 +1,39 @@
+---
+github: "shanselman"
+name: "Scott Hanselman"
+headline: "Small Windows comforts, terminal helpers, productivity papercuts, and joyful nonsense."
+website_url: "https://www.hanselman.com"
+links:
+  - label: "GitHub"
+    url: "https://github.com/shanselman"
+  - label: "Blog"
+    url: "https://www.hanselman.com/blog"
+notes:
+  - "A lot of these tools smooth over daily friction: panes, desktops, package updates, certificates, shipping labels."
+  - "Some are intentionally tiny and specific. Toasty is a 229 KB notification CLI; BabySmash is exactly what it sounds like."
+  - "The common thread is practical tinkering: make the rough edge visible, shave it down, share the result."
+sections:
+  - title: "Windows workbench"
+    description: "Desktop and tray utilities for small Windows annoyances: virtual desktops, peeking at the wallpaper, posture nudges, edge lights, handheld companion controls, and Terminal pane cleanup."
+    toolSlugs:
+      - "maximize-to-virtual-desktop"
+      - "peekdesktop"
+      - "posturr-windows"
+      - "windows-edge-light"
+      - "openclaw-windows-hub"
+      - "splitpanefix"
+  - title: "Terminal and developer helpers"
+    description: "Tools for package updates, toast notifications, certificate inspection, and focused presentation timing."
+    toolSlugs:
+      - "winget-tui"
+      - "toasty"
+      - "cert-inspector"
+      - "markwatch"
+  - title: "Useful one-offs and odd joys"
+    description: "Browser automation, health-data experiments, and keyboard-smashing fun for small kids."
+    toolSlugs:
+      - "depop-to-pirateship"
+      - "nightscout-cgm-skill"
+      - "babysmash"
+---
+Scott keeps a bench full of tiny utilities: little Windows affordances, command-line helpers, browser glue, speaking timers, health experiments, and a few bits of software that exist because computers should occasionally be silly.

--- a/src/lib/authors.ts
+++ b/src/lib/authors.ts
@@ -24,12 +24,20 @@ export interface AuthorProfileSection {
   toolSlugs: string[];
 }
 
+export interface AuthorProfileLink {
+  label: string;
+  url: string;
+}
+
 export interface AuthorProfile {
   github: string;
-  headline: string;
+  name?: string;
+  headline?: string;
   intro: string;
-  notes: string[];
-  sections: AuthorProfileSection[];
+  website_url?: string;
+  links?: AuthorProfileLink[];
+  notes?: string[];
+  sections?: AuthorProfileSection[];
 }
 
 export const customAuthorProfiles: Record<string, AuthorProfile> = {

--- a/src/pages/authors/[github].astro
+++ b/src/pages/authors/[github].astro
@@ -4,7 +4,7 @@ import Header from '../../components/Header.astro';
 import Footer from '../../components/Footer.astro';
 import ToolCard from '../../components/ToolCard.astro';
 import { getCollection } from 'astro:content';
-import { buildAuthorIntro, buildAuthors, customAuthorProfiles, getAvatarUrl, slugForTool } from '../../lib/authors';
+import { buildAuthorIntro, buildAuthors, customAuthorProfiles, getAvatarUrl, normalizeGitHubHandle, slugForTool, type AuthorProfile } from '../../lib/authors';
 import { fetchStarCounts, getGitHubRepo } from '../../lib/github';
 
 export async function getStaticPaths() {
@@ -22,11 +22,28 @@ if (!author) {
   throw new Error(`Author not found: ${Astro.params.github}`);
 }
 
-const profile = customAuthorProfiles[author.github];
+const profileEntries = await getCollection('authors');
+const contentProfileEntry = profileEntries.find(entry => {
+  const handle = entry.data.github || entry.id.replace(/\.md$/, '');
+  return normalizeGitHubHandle(handle) === author.github;
+});
+const contentProfile = contentProfileEntry ? {
+  ...contentProfileEntry.data,
+  github: normalizeGitHubHandle(contentProfileEntry.data.github || contentProfileEntry.id.replace(/\.md$/, '')),
+  intro: contentProfileEntry.data.intro || contentProfileEntry.body.trim(),
+} satisfies AuthorProfile : undefined;
+const profile = contentProfile || customAuthorProfiles[author.github];
+const displayName = profile?.name || author.name;
 const intro = profile?.intro || buildAuthorIntro(author);
-const headline = profile?.headline || `${author.toolCount} ${author.toolCount === 1 ? 'tiny tool' : 'tiny tools'} by ${author.name}`;
-const metaDescription = `${author.name} (@${author.github}) has ${author.toolCount} ${author.toolCount === 1 ? 'tool' : 'tools'} in Tiny Tool Town. ${author.tags.slice(0, 4).map(tag => tag.name).join(', ')}.`;
+const headline = profile?.headline || `${author.toolCount} ${author.toolCount === 1 ? 'tiny tool' : 'tiny tools'} by ${displayName}`;
+const metaDescription = `${displayName} (@${author.github}) has ${author.toolCount} ${author.toolCount === 1 ? 'tool' : 'tools'} in Tiny Tool Town. ${author.tags.slice(0, 4).map(tag => tag.name).join(', ')}.`;
 const authorFeedPath = `/rss/authors/${author.github}.xml`;
+const customizeUrl = `https://github.com/shanselman/TinyToolTown/issues/new?template=customize-author.yml&title=${encodeURIComponent(`[Author] @${author.github}`)}`;
+const profileLinks = [
+  ...(profile?.website_url ? [{ label: 'Website', url: profile.website_url }] : []),
+  ...(profile?.links || []),
+];
+const profileNotes = profile?.notes || [];
 
 const repoMap = new Map<string, string>();
 for (const tool of author.tools) {
@@ -40,7 +57,7 @@ for (const [slug, repo] of repoMap) {
 }
 
 const toolsBySlug = new Map(author.tools.map(tool => [slugForTool(tool), tool]));
-const profileSections = profile?.sections
+const profileSections = (profile?.sections || [])
   .map(section => ({
     ...section,
     tools: section.toolSlugs.map(slug => toolsBySlug.get(slug)).filter((tool): tool is typeof author.tools[number] => Boolean(tool)),
@@ -57,10 +74,10 @@ function formatDate(value: string) {
 ---
 
 <BaseLayout
-  title={`${author.name} (@${author.github}) - Tiny Tool Town`}
+  title={`${displayName} (@${author.github}) - Tiny Tool Town`}
   description={metaDescription}
   rssHref={authorFeedPath}
-  rssTitle={`${author.name}'s Tiny Tool Town tools`}
+  rssTitle={`${displayName}'s Tiny Tool Town tools`}
 >
   <Header />
 
@@ -76,7 +93,7 @@ function formatDate(value: string) {
     <section class:list={["author-hero", { "custom-hero": Boolean(profile) }]}>
       <img
         src={getAvatarUrl(author.github, 240)}
-        alt={author.name}
+        alt={displayName}
         class="author-avatar"
         width="120"
         height="120"
@@ -84,7 +101,7 @@ function formatDate(value: string) {
       />
       <div class="author-hero-copy">
         <p class="eyebrow">Author showcase</p>
-        <h1>{author.name}</h1>
+        <h1>{displayName}</h1>
         <p class="handle">
           <a href={`https://github.com/${author.github}`} target="_blank" rel="noopener">@{author.github}</a>
         </p>
@@ -94,13 +111,21 @@ function formatDate(value: string) {
           <a href={`https://github.com/${author.github}`} class="btn btn-primary" target="_blank" rel="noopener">GitHub profile</a>
           <a href={authorFeedPath} class="btn btn-secondary">RSS feed</a>
           <a href="#tools" class="btn btn-secondary">{author.toolCount} {author.toolCount === 1 ? 'tool' : 'tools'}</a>
+          <a href={customizeUrl} class="btn btn-secondary" target="_blank" rel="noopener">Customize this page</a>
         </div>
+        {profileLinks.length > 0 && (
+          <div class="profile-links" aria-label="Author links">
+            {profileLinks.map(link => (
+              <a href={link.url} target="_blank" rel="noopener">{link.label}</a>
+            ))}
+          </div>
+        )}
       </div>
     </section>
 
-    {profile && (
+    {profileNotes.length > 0 && (
       <section class="profile-notes" aria-label="Workbench notes">
-        {profile.notes.map(note => (
+        {profileNotes.map(note => (
           <p>{note}</p>
         ))}
       </section>
@@ -287,6 +312,23 @@ function formatDate(value: string) {
     gap: 0.75rem;
     flex-wrap: wrap;
     margin-top: 1.5rem;
+  }
+
+  .profile-links {
+    display: flex;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+    margin-top: 1rem;
+  }
+
+  .profile-links a {
+    color: var(--color-accent);
+    font-weight: 700;
+    text-decoration: none;
+  }
+
+  .profile-links a:hover {
+    text-decoration: underline;
   }
 
   .profile-notes {

--- a/src/pages/authors/index.astro
+++ b/src/pages/authors/index.astro
@@ -26,7 +26,11 @@ function formatDate(value: string) {
       <p class="eyebrow">Makers in town</p>
       <h1>Author directory</h1>
       <p class="hero-copy">
-        Real pages for the people building Tiny Tool Town: {authors.length} authors and {totalTools} tiny tools.
+        Real maker pages for the people building Tiny Tool Town: {authors.length} authors and {totalTools} tiny tools.
+        If one of your tools is listed, your author page already exists automatically.
+      </p>
+      <p class="hero-copy small">
+        Want to personalize yours? Open a <a href="https://github.com/shanselman/TinyToolTown/issues/new?template=customize-author.yml" target="_blank" rel="noopener">Customize an Author Page issue</a> or send a PR with an author profile.
       </p>
     </section>
 
@@ -138,6 +142,16 @@ function formatDate(value: string) {
     color: var(--color-text-muted);
     font-size: 1.15rem;
     line-height: 1.7;
+  }
+
+  .hero-copy.small {
+    font-size: 1rem;
+    margin-top: 0.75rem;
+  }
+
+  .hero-copy a {
+    color: var(--color-accent);
+    font-weight: 700;
   }
 
   .authors-filter {


### PR DESCRIPTION
## Summary

Adds the public-facing docs and customization path for Tiny Tool Town author pages:

- Documents that every accepted tool automatically creates an author page and RSS feed
- Adds a `Customize an Author Page` issue template so authors can claim/update their page
- Adds optional `src/content/authors/*.md` profiles for PR-based customization
- Moves Scott's curated showcase into the new author content model as the first example
- Adds a visible `Customize this page` CTA on author pages
- Updates the author directory copy and submission issue copy to advertise author pages
- Updates the import bot success comment to include tool page, author page, RSS feed, and customization link

## Verification

- `npm test` — 43 tests passed
- `npm run build` — 841 pages built
- Verified generated `dist/authors/shanselman/index.html` includes the customized profile and CTA
- Verified generated `dist/authors/index.html` explains automatic author pages
