### PR TITLE
Mark generated author pages as claimable

### DIFF
--- a/.github/ISSUE_TEMPLATE/customize-author.yml
+++ b/.github/ISSUE_TEMPLATE/customize-author.yml
@@ -1,4 +1,4 @@
-name: 👤 Customize an Author Page
+name: 👤 Claim or Customize an Author Page
 description: Claim or update your Tiny Tool Town maker page.
 title: "[Author] @"
 labels: ["author-page"]
@@ -6,11 +6,13 @@ body:
   - type: markdown
     attributes:
       value: |
-        ## Customize your Tiny Tool Town author page 👤
+        ## Claim or customize your Tiny Tool Town author page 👤
 
         Everyone with an accepted tool already gets an automatic page at:
 
         `https://www.tinytooltown.com/authors/YOUR-GITHUB-USERNAME/`
+
+        If your page says **Unclaimed automatic page**, this issue is how you claim it.
 
         Use this form if you want to add a bio, headline, links, notes, or featured groups of tools.
         For safety, requests should come from the same GitHub account as the author page you're claiming.

--- a/.github/ISSUE_TEMPLATE/submit-tool.yml
+++ b/.github/ISSUE_TEMPLATE/submit-tool.yml
@@ -12,7 +12,7 @@ body:
         Your GitHub username also creates your author page automatically:
         `https://www.tinytooltown.com/authors/YOUR-GITHUB-USERNAME/`
 
-        After your tool is accepted, you can use the **Customize an Author Page** issue form if you want to add a bio, links, or featured groups of your tools.
+        After your tool is accepted, you can use the **Claim or Customize an Author Page** issue form if you want to remove the unclaimed notice and add a bio, links, or featured groups of your tools.
 
   - type: input
     id: name

--- a/.github/workflows/batch-approve.yml
+++ b/.github/workflows/batch-approve.yml
@@ -603,7 +603,7 @@ jobs:
                   owner,
                   repo,
                   issue_number: item.issueNumber,
-                  body: `🏘️ **Welcome to Tiny Tool Town!**\n\n**${item.name}** has been added and will be live once the site rebuilds:\n\n- Tool page: https://www.tinytooltown.com/tools/${item.slug}/\n- Author page: https://www.tinytooltown.com/authors/${item.authorGithub}/\n- Author RSS feed: https://www.tinytooltown.com/rss/authors/${item.authorGithub}.xml\n\nWant to customize your author page? Open the **Customize an Author Page** issue form: https://github.com/shanselman/TinyToolTown/issues/new?template=customize-author.yml&title=${encodeURIComponent(`[Author] @${item.authorGithub}`)}`,
+                  body: `🏘️ **Welcome to Tiny Tool Town!**\n\n**${item.name}** has been added and will be live once the site rebuilds:\n\n- Tool page: https://www.tinytooltown.com/tools/${item.slug}/\n- Author page: https://www.tinytooltown.com/authors/${item.authorGithub}/\n- Author RSS feed: https://www.tinytooltown.com/rss/authors/${item.authorGithub}.xml\n\nYour author page starts as an unclaimed automatic page. Want to claim/customize it? Open the **Claim or Customize an Author Page** issue form from your GitHub account: https://github.com/shanselman/TinyToolTown/issues/new?template=customize-author.yml&title=${encodeURIComponent(`[Author] @${item.authorGithub}`)}`,
                 });
                 await github.rest.issues.update({
                   owner,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,14 +38,16 @@ https://www.tinytooltown.com/authors/YOUR-GITHUB-USERNAME/
 Author pages collect all tools for that GitHub handle, plus tags, languages,
 latest additions, GitHub avatar, and an author-specific RSS feed.
 
-Authors can customize their page in two ways:
+New generated pages are marked as **unclaimed automatic pages** until the author
+adds profile content. Authors can claim and customize their page in two ways:
 
-- Open a [Customize an Author Page issue](https://github.com/shanselman/TinyToolTown/issues/new?template=customize-author.yml)
+- Open a [Claim or Customize an Author Page issue](https://github.com/shanselman/TinyToolTown/issues/new?template=customize-author.yml)
   with the bio, headline, links, notes, or featured groups they want.
 - Open a PR adding `src/content/authors/YOUR-GITHUB-USERNAME.md`.
 
 For safety, author-page customization requests should come from the matching
 GitHub account, or explain why the requester is authorized to make the change.
+Once accepted, the unclaimed notice disappears.
 
 Example author profile:
 

--- a/README.md
+++ b/README.md
@@ -57,13 +57,13 @@ Why did you build it? Why is it delightful?
 
 Author pages are generated from the `author_github` value on each tool. You do **not** need to create a separate author file to get a page — submit one accepted tool and your author page exists automatically.
 
-Want to customize it? You have two options:
+New author pages start as **unclaimed automatic pages**. Want to claim and customize yours? You have two options:
 
 ### Option 1: Author Page Issue
 
-Open a [Customize an Author Page issue](https://github.com/shanselman/TinyToolTown/issues/new?template=customize-author.yml) and tell us what bio, headline, links, notes, or featured tool groups you want.
+Open a [Claim or Customize an Author Page issue](https://github.com/shanselman/TinyToolTown/issues/new?template=customize-author.yml) and tell us what bio, headline, links, notes, or featured tool groups you want.
 
-For safety, the request should come from the same GitHub account as the author page being claimed.
+For safety, the request should come from the same GitHub account as the author page being claimed. Once accepted, the unclaimed notice disappears and your profile content is shown.
 
 ### Option 2: Pull Request
 

--- a/src/pages/authors/[github].astro
+++ b/src/pages/authors/[github].astro
@@ -33,6 +33,7 @@ const contentProfile = contentProfileEntry ? {
   intro: contentProfileEntry.data.intro || contentProfileEntry.body.trim(),
 } satisfies AuthorProfile : undefined;
 const profile = contentProfile || customAuthorProfiles[author.github];
+const isClaimed = Boolean(profile);
 const displayName = profile?.name || author.name;
 const intro = profile?.intro || buildAuthorIntro(author);
 const headline = profile?.headline || `${author.toolCount} ${author.toolCount === 1 ? 'tiny tool' : 'tiny tools'} by ${displayName}`;
@@ -111,7 +112,7 @@ function formatDate(value: string) {
           <a href={`https://github.com/${author.github}`} class="btn btn-primary" target="_blank" rel="noopener">GitHub profile</a>
           <a href={authorFeedPath} class="btn btn-secondary">RSS feed</a>
           <a href="#tools" class="btn btn-secondary">{author.toolCount} {author.toolCount === 1 ? 'tool' : 'tools'}</a>
-          <a href={customizeUrl} class="btn btn-secondary" target="_blank" rel="noopener">Customize this page</a>
+          <a href={customizeUrl} class="btn btn-secondary" target="_blank" rel="noopener">{isClaimed ? 'Customize this page' : 'Claim this page'}</a>
         </div>
         {profileLinks.length > 0 && (
           <div class="profile-links" aria-label="Author links">
@@ -122,6 +123,20 @@ function formatDate(value: string) {
         )}
       </div>
     </section>
+
+    {!isClaimed && (
+      <section class="claim-notice" aria-label="Unclaimed author page">
+        <div>
+          <p class="claim-kicker">Unclaimed automatic page</p>
+          <h2>Are you @{author.github}?</h2>
+          <p>
+            This page was generated automatically from accepted Tiny Tool Town submissions.
+            Claim it by opening an author-page issue from your GitHub account, then add a bio, links, notes, and featured tool groups.
+          </p>
+        </div>
+        <a href={customizeUrl} class="btn btn-primary" target="_blank" rel="noopener">Claim @{author.github}</a>
+      </section>
+    )}
 
     {profileNotes.length > 0 && (
       <section class="profile-notes" aria-label="Workbench notes">
@@ -331,6 +346,37 @@ function formatDate(value: string) {
     text-decoration: underline;
   }
 
+  .claim-notice {
+    display: flex;
+    justify-content: space-between;
+    gap: 1.5rem;
+    align-items: center;
+    padding: 1.25rem;
+    margin-bottom: 1.5rem;
+    background: linear-gradient(135deg, rgba(61, 169, 252, 0.12), rgba(255, 137, 6, 0.08)), var(--color-bg-card);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-lg);
+  }
+
+  .claim-notice h2 {
+    margin-bottom: 0.35rem;
+  }
+
+  .claim-notice p {
+    color: var(--color-text-muted);
+    line-height: 1.7;
+    max-width: 780px;
+  }
+
+  .claim-kicker {
+    color: var(--color-primary) !important;
+    font-size: 0.8rem;
+    font-weight: 800;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    margin-bottom: 0.35rem;
+  }
+
   .profile-notes {
     display: grid;
     grid-template-columns: repeat(3, 1fr);
@@ -488,9 +534,15 @@ function formatDate(value: string) {
 
   @media (max-width: 820px) {
     .author-hero,
+    .claim-notice,
     .showcase-section,
     .terms-section {
       grid-template-columns: 1fr;
+    }
+
+    .claim-notice {
+      align-items: stretch;
+      flex-direction: column;
     }
 
     .profile-notes,

--- a/src/pages/authors/index.astro
+++ b/src/pages/authors/index.astro
@@ -30,7 +30,7 @@ function formatDate(value: string) {
         If one of your tools is listed, your author page already exists automatically.
       </p>
       <p class="hero-copy small">
-        Want to personalize yours? Open a <a href="https://github.com/shanselman/TinyToolTown/issues/new?template=customize-author.yml" target="_blank" rel="noopener">Customize an Author Page issue</a> or send a PR with an author profile.
+        Want to claim and personalize yours? Open a <a href="https://github.com/shanselman/TinyToolTown/issues/new?template=customize-author.yml" target="_blank" rel="noopener">Claim or Customize an Author Page issue</a> or send a PR with an author profile.
       </p>
     </section>
 


### PR DESCRIPTION
## Summary

Makes automatic author pages explicitly claimable:

- Adds an "Unclaimed automatic page" notice to generated author pages without custom profile content
- Changes the CTA to "Claim this page" for unclaimed pages and keeps "Customize this page" for claimed/customized pages
- Renames the issue flow to "Claim or Customize an Author Page"
- Updates README, CONTRIBUTING, submit issue copy, author directory copy, and import bot success comments to explain the claim flow

## Verification

- `npm ci`
- `npm test` — 43 tests passed
- `npm run build` — 841 pages built
- Verified an uncustomized page (`/authors/turner-levey/`) includes the unclaimed notice and claim CTA
- Verified the customized Scott page does not show the unclaimed notice
