### PR TITLE
Verify author page claim ownership

### DIFF
--- a/.github/ISSUE_TEMPLATE/customize-author.yml
+++ b/.github/ISSUE_TEMPLATE/customize-author.yml
@@ -15,7 +15,8 @@ body:
         If your page says **Unclaimed automatic page**, this issue is how you claim it.
 
         Use this form if you want to add a bio, headline, links, notes, or featured groups of tools.
-        For safety, requests should come from the same GitHub account as the author page you're claiming.
+        For safety, this issue must be opened from the same GitHub account as the author page you're claiming.
+        A workflow will mark claims as verified only when the issue author matches this username.
 
   - type: input
     id: github
@@ -84,7 +85,7 @@ body:
     attributes:
       label: Checklist
       options:
-        - label: I am requesting changes for my own GitHub author page, or I can explain why I am authorized to request them.
+        - label: I am signed in as the same GitHub account as the author page I am claiming.
           required: true
         - label: I understand maintainers may edit for length, clarity, and site fit.
           required: true

--- a/.github/workflows/validate-author-claim.yml
+++ b/.github/workflows/validate-author-claim.yml
@@ -1,0 +1,123 @@
+name: Validate Author Page Claim
+
+on:
+  issues:
+    types: [opened, edited, reopened, labeled]
+
+permissions:
+  issues: write
+  contents: read
+
+jobs:
+  validate:
+    name: Verify claimant matches GitHub username
+    runs-on: ubuntu-latest
+    if: >-
+      contains(github.event.issue.labels.*.name, 'author-page') ||
+      (github.event.action == 'labeled' && github.event.label.name == 'author-page')
+    steps:
+      - name: Validate author-page claim
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const issue = context.payload.issue;
+            const body = issue.body || '';
+            const actor = (issue.user?.login || '').toLowerCase();
+
+            function extractIssueFormValue(markdown, label) {
+              const escaped = label.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+              const re = new RegExp(`###\\s+${escaped}\\s*\\n+([\\s\\S]*?)(?=\\n###\\s+|$)`, 'i');
+              const match = markdown.match(re);
+              if (!match) return '';
+              return match[1]
+                .replace(/<!--([\\s\\S]*?)-->/g, '')
+                .replace(/^_No response_$/gim, '')
+                .trim();
+            }
+
+            function normalizeHandle(value) {
+              return value
+                .split(/\r?\n/)[0]
+                .trim()
+                .replace(/^@/, '')
+                .replace(/^https:\/\/github\.com\//i, '')
+                .split(/[/?#]/)[0]
+                .toLowerCase();
+            }
+
+            const requested = normalizeHandle(extractIssueFormValue(body, 'GitHub username for this author page'));
+            const labels = issue.labels.map(label => typeof label === 'string' ? label : label.name);
+            const hasInvalid = labels.includes('invalid-author-claim');
+            const hasVerified = labels.includes('claim-verified');
+
+            async function ensureLabel(name, color, description) {
+              try {
+                await github.rest.issues.getLabel({ owner, repo, name });
+              } catch (error) {
+                if (error.status !== 404) throw error;
+                await github.rest.issues.createLabel({ owner, repo, name, color, description });
+              }
+            }
+
+            await ensureLabel('claim-verified', '0e8a16', 'Author-page claim opened by matching GitHub account');
+            await ensureLabel('invalid-author-claim', 'd73a4a', 'Author-page claim does not match issue author');
+
+            if (!requested) {
+              if (!hasInvalid) {
+                await github.rest.issues.addLabels({ owner, repo, issue_number: issue.number, labels: ['invalid-author-claim'] });
+              }
+              if (hasVerified) {
+                await github.rest.issues.removeLabel({ owner, repo, issue_number: issue.number, name: 'claim-verified' }).catch(() => {});
+              }
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: issue.number,
+                body: '⚠️ I could not find the requested GitHub username in this author-page claim. Please use the **Claim or Customize an Author Page** issue form and include the GitHub username for the page you want to claim.',
+              });
+              core.setFailed('Missing GitHub username for author-page claim.');
+              return;
+            }
+
+            if (requested !== actor) {
+              if (!hasInvalid) {
+                await github.rest.issues.addLabels({ owner, repo, issue_number: issue.number, labels: ['invalid-author-claim'] });
+              }
+              if (hasVerified) {
+                await github.rest.issues.removeLabel({ owner, repo, issue_number: issue.number, name: 'claim-verified' }).catch(() => {});
+              }
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: issue.number,
+                body: `⚠️ Author-page claims must be opened from the same GitHub account as the page being claimed.\n\nThis issue was opened by @${actor}, but it requests @${requested}.\n\nIf you are @${requested}, please open a new claim issue while signed in as @${requested}. If this is a special case, a maintainer can review it manually, but this claim is not automatically verified.`,
+              });
+              core.setFailed(`Claim mismatch: actor ${actor}, requested ${requested}`);
+              return;
+            }
+
+            if (hasInvalid) {
+              await github.rest.issues.removeLabel({ owner, repo, issue_number: issue.number, name: 'invalid-author-claim' }).catch(() => {});
+            }
+            if (!hasVerified) {
+              await github.rest.issues.addLabels({ owner, repo, issue_number: issue.number, labels: ['claim-verified'] });
+            }
+
+            const marker = '<!-- author-claim-verified -->';
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner,
+              repo,
+              issue_number: issue.number,
+              per_page: 100,
+            });
+            const alreadyCommented = comments.some(comment => comment.body?.includes(marker));
+            if (!alreadyCommented) {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: issue.number,
+                body: `${marker}\n✅ Claim verified: this issue was opened by @${actor} for their own author page. Maintainers can now review the requested profile content.`,
+              });
+            }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,9 +45,9 @@ adds profile content. Authors can claim and customize their page in two ways:
   with the bio, headline, links, notes, or featured groups they want.
 - Open a PR adding `src/content/authors/YOUR-GITHUB-USERNAME.md`.
 
-For safety, author-page customization requests should come from the matching
-GitHub account, or explain why the requester is authorized to make the change.
-Once accepted, the unclaimed notice disappears.
+For safety, author-page customization issues must come from the matching GitHub
+account. A GitHub Action marks matching claims `claim-verified` and mismatches
+`invalid-author-claim`. Once accepted, the unclaimed notice disappears.
 
 Example author profile:
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ New author pages start as **unclaimed automatic pages**. Want to claim and custo
 
 Open a [Claim or Customize an Author Page issue](https://github.com/shanselman/TinyToolTown/issues/new?template=customize-author.yml) and tell us what bio, headline, links, notes, or featured tool groups you want.
 
-For safety, the request should come from the same GitHub account as the author page being claimed. Once accepted, the unclaimed notice disappears and your profile content is shown.
+For safety, the issue must be opened from the same GitHub account as the author page being claimed. A GitHub Action marks matching claims `claim-verified` and marks mismatches `invalid-author-claim`. Once accepted, the unclaimed notice disappears and your profile content is shown.
 
 ### Option 2: Pull Request
 


### PR DESCRIPTION
## Summary

Locks down author-page claiming so random users cannot silently claim someone else's page.

- Adds a GitHub Action for `author-page` issues
- Parses the requested `GitHub username for this author page` from the issue form
- Compares it to the GitHub account that opened the issue
- Adds `claim-verified` when they match
- Adds `invalid-author-claim`, comments, and fails the check when they do not match
- Creates the verification labels automatically if needed
- Updates the issue form and docs to say claims must be opened from the matching GitHub account

This does not prevent someone from opening a bogus issue — GitHub won't let us block issue creation — but it prevents the workflow from treating that claim as valid and makes the mismatch obvious to maintainers.

## Verification

- Tested the parser locally with an issue-form-style body
- `npm ci`
- `npm test` — 43 tests passed
- `npm run build` — 841 pages built
