### PR TITLE
Fix author links on tool cards

### DIFF
--- a/src/components/ToolCard.astro
+++ b/src/components/ToolCard.astro
@@ -75,14 +75,16 @@ const langColor = language ? langColors[language] || '#8b949e' : null;
         )}
       </div>
       <div class="card-author">
-        <img
-          src={getAvatarUrl(author_github, 24)}
-          alt={author}
-          class="author-avatar"
-          loading="lazy"
-          decoding="async"
-        />
-        <a href={authorPath} class="author-name">{author}</a>
+        <a href={authorPath} class="author-link" aria-label={`View author page for ${author}`}>
+          <img
+            src={getAvatarUrl(author_github, 24)}
+            alt=""
+            class="author-avatar"
+            loading="lazy"
+            decoding="async"
+          />
+          <span class="author-name">{author}</span>
+        </a>
         {typeof stars === 'number' ? (
           <span class="card-stars-count">⭐ {stars.toLocaleString()}</span>
         ) : repo ? (
@@ -355,16 +357,32 @@ const langColor = language ? langColors[language] || '#8b949e' : null;
     border-radius: 50%;
   }
 
-  .author-name {
-    font-size: 0.8rem;
+  .author-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    min-width: 0;
     color: var(--color-text-muted);
     text-decoration: none;
     pointer-events: auto;
+    position: relative;
+    z-index: 3;
   }
 
-  .author-name:hover {
+  .author-name {
+    font-size: 0.8rem;
+  }
+
+  .author-link:hover .author-name,
+  .author-link:focus-visible .author-name {
     text-decoration: underline;
     color: var(--color-primary);
+  }
+
+  .author-link:focus-visible {
+    outline: 2px solid var(--color-primary);
+    outline-offset: 3px;
+    border-radius: 999px;
   }
 
   .card-stars {


### PR DESCRIPTION
## Summary

Fixes author links inside tool cards so they navigate to author pages instead of falling through to the card's tool-page link.

- Wraps avatar + author name in a dedicated `.author-link`
- Keeps the full-card tool link for the rest of the card
- Raises the author link above the card overlay and keeps it pointer-interactive
- Adds focus styling for keyboard navigation

## Verification

- `npm ci`
- `npm test` — 43 tests passed
- `npm run build` — 841 pages built
- Verified generated homepage HTML includes `/authors/.../` links with `class="author-link"`
