### PR TITLE
Add support for multiple authors

### DIFF
--- a/.github/ISSUE_TEMPLATE/submit-tool.yml
+++ b/.github/ISSUE_TEMPLATE/submit-tool.yml
@@ -68,7 +68,8 @@ body:
     id: author
     attributes:
       label: Your Name
-      placeholder: "e.g., Jane Developer"
+      description: Enter one name, or multiple names separated by commas in the same order as GitHub usernames below.
+      placeholder: "e.g., Jane Developer, John Builder"
     validations:
       required: true
 
@@ -76,7 +77,8 @@ body:
     id: author_github
     attributes:
       label: Your GitHub Username
-      placeholder: "e.g., janedev"
+      description: Enter one username, or multiple usernames separated by commas to match the names above.
+      placeholder: "e.g., janedev, johnbuilder"
     validations:
       required: true
 

--- a/scripts/generate-social.mjs
+++ b/scripts/generate-social.mjs
@@ -28,6 +28,7 @@ import {
 } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { getToolAuthors } from '../src/lib/author-utils.js';
 import { renderSocialCard, renderAuthorSocialCard } from './social-card.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -71,20 +72,21 @@ function parseToolFile(content) {
   };
 }
 
-function normalizeHandle(handle) {
-  return (handle || '').trim().replace(/^@+/, '').toLowerCase();
-}
-
 // Aggregate tool data into one entry per author handle, mirroring
 // src/lib/authors.ts buildAuthors() (name/tags/languages by frequency).
 function buildAuthors(tools) {
   const groups = new Map();
+  const authorNames = new Map();
   for (const tool of tools) {
-    const github = normalizeHandle(tool.data.author_github);
-    if (!github) continue;
-    const group = groups.get(github) || [];
-    group.push(tool);
-    groups.set(github, group);
+    for (const toolAuthor of getToolAuthors(tool)) {
+      const group = groups.get(toolAuthor.github) || [];
+      group.push(tool);
+      groups.set(toolAuthor.github, group);
+
+      const names = authorNames.get(toolAuthor.github) || [];
+      names.push(toolAuthor.name);
+      authorNames.set(toolAuthor.github, names);
+    }
   }
 
   const mostFrequent = (values) => {
@@ -104,9 +106,14 @@ function buildAuthors(tools) {
 
   const authors = [];
   for (const [github, authorTools] of groups) {
-    const name = mostFrequent(authorTools.map((tool) => tool.data.author))[0]
-      || authorTools[0].data.author
-      || `@${github}`;
+    let name = mostFrequent(authorNames.get(github) || [])[0];
+    const firstTool = authorTools[0];
+    if (!name && firstTool) {
+      name = getToolAuthors(firstTool).find((author) => author.github === github)?.name;
+    }
+    if (!name) {
+      name = firstTool?.data.author || `@${github}`;
+    }
     authors.push({
       github,
       name,

--- a/src/components/TikTokView.astro
+++ b/src/components/TikTokView.astro
@@ -1,6 +1,7 @@
 ---
 // Shorts-style viewer for TinyToolTown
 import { getGitHubRepo } from '../lib/github';
+import { getToolAuthors } from '../lib/authors';
 
 interface Props {
   tools: any[];
@@ -14,8 +15,7 @@ const shortsToolsData = tools.map((tool) => ({
   slug: tool.id.replace(/\.md$/, ''),
   name: tool.data.name,
   tagline: tool.data.tagline,
-  author: tool.data.author,
-  authorGithub: tool.data.author_github,
+  authors: getToolAuthors(tool.data),
   thumbnail: tool.data.thumbnail ?? null,
   githubUrl: tool.data.github_url,
   repo: getGitHubRepo(tool.data.github_url),
@@ -94,7 +94,7 @@ const shortsToolsJson = JSON.stringify(shortsToolsData).replace(/</g, '\\u003c')
 
     type ShortsToolEntry = {
       slug: string; name: string; tagline: string;
-      author: string; authorGithub: string;
+      authors: { name: string; github: string }[];
       thumbnail: string | null; githubUrl: string;
       repo: string | null; tags: string[];
     };
@@ -127,9 +127,17 @@ const shortsToolsJson = JSON.stringify(shortsToolsData).replace(/</g, '\\u003c')
       sec.querySelector('.tool-description')!.textContent = t.tagline;
 
       const av = sec.querySelector<HTMLImageElement>('.creator-avatar')!;
-      av.src = `https://avatars.githubusercontent.com/${t.authorGithub}?s=32`;
-      av.alt = t.author;
-      sec.querySelector('.creator-handle')!.textContent = `@${t.author}`;
+      const primaryAuthor = t.authors[0];
+      if (primaryAuthor) {
+        av.src = `https://avatars.githubusercontent.com/${primaryAuthor.github}?s=32`;
+        av.alt = primaryAuthor.name;
+        sec.querySelector('.creator-handle')!.textContent = t.authors.length > 1
+          ? `${primaryAuthor.name} + ${t.authors.length - 1} more`
+          : primaryAuthor.name;
+      } else {
+        av.remove();
+        sec.querySelector('.creator-handle')!.textContent = 'Unknown author';
+      }
 
       const tagsEl = sec.querySelector('.metadata-tags')!;
       t.tags.forEach(tag => {

--- a/src/components/ToolCard.astro
+++ b/src/components/ToolCard.astro
@@ -1,6 +1,6 @@
 ---
 import { getGitHubRepo } from '../lib/github';
-import { getAuthorPath, getAvatarUrl } from '../lib/authors';
+import { getAuthorPath, getAvatarUrl, getToolAuthors } from '../lib/authors';
 
 interface Props {
   name: string;
@@ -18,7 +18,7 @@ interface Props {
 
 const { name, slug, tagline, author, author_github, tags, language, featured, thumbnail, github_url, stars } = Astro.props;
 const repo = getGitHubRepo(github_url);
-const authorPath = getAuthorPath(author_github);
+const authors = getToolAuthors({ author, author_github });
 
 const langColors: Record<string, string> = {
   'C#': '#178600',
@@ -75,16 +75,20 @@ const langColor = language ? langColors[language] || '#8b949e' : null;
         )}
       </div>
       <div class="card-author">
-        <a href={authorPath} class="author-link" aria-label={`View author page for ${author}`}>
-          <img
-            src={getAvatarUrl(author_github, 24)}
-            alt=""
-            class="author-avatar"
-            loading="lazy"
-            decoding="async"
-          />
-          <span class="author-name">{author}</span>
-        </a>
+        <div class="author-links">
+          {authors.map((toolAuthor) => (
+            <a href={getAuthorPath(toolAuthor.github)} class="author-link" aria-label={`View author page for ${toolAuthor.name}`}>
+              <img
+                src={getAvatarUrl(toolAuthor.github, 24)}
+                alt=""
+                class="author-avatar"
+                loading="lazy"
+                decoding="async"
+              />
+              <span class="author-name">{toolAuthor.name}</span>
+            </a>
+          ))}
+        </div>
         {typeof stars === 'number' ? (
           <span class="card-stars-count">⭐ {stars.toLocaleString()}</span>
         ) : repo ? (
@@ -355,6 +359,13 @@ const langColor = language ? langColors[language] || '#8b949e' : null;
     width: 20px;
     height: 20px;
     border-radius: 50%;
+  }
+
+  .author-links {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    min-width: 0;
   }
 
   .author-link {

--- a/src/content/tools/resizeme.md
+++ b/src/content/tools/resizeme.md
@@ -1,8 +1,8 @@
 ---
 name: "ResizeMe"
 tagline: "Intelligent window resizer for Windows and macOS"
-author: "James Montemagno & Burke Holland"
-author_github: "burkeholland"
+author: "Burke Holland, James Montemagno"
+author_github: "burkeholland,jamesmontemagno"
 github_url: "https://github.com/burkeholland/resize-me"
 thumbnail: "/thumbnails/resizeme.gif"
 tags: []

--- a/src/lib/__tests__/authors.test.ts
+++ b/src/lib/__tests__/authors.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import type { ToolEntry } from '../authors';
-import { buildAuthorIntro, buildAuthors, getAuthorPath, getAvatarUrl, normalizeGitHubHandle, slugForTool } from '../authors';
+import { buildAuthorIntro, buildAuthors, formatToolAuthors, getAuthorPath, getAvatarUrl, getToolAuthors, normalizeGitHubHandle, slugForTool } from '../authors';
 
 function tool(id: string, data: Partial<ToolEntry['data']> & Pick<ToolEntry['data'], 'name' | 'author' | 'author_github' | 'tags' | 'date_added'>): ToolEntry {
   return {
@@ -58,6 +58,36 @@ describe('author helpers', () => {
       { name: 'cli', count: 1 },
     ]);
     expect(authors[0].languages.map(language => language.name)).toEqual(['C#', 'PowerShell']);
+  });
+
+  it('supports comma-delimited co-authors', () => {
+    const [burke, james] = getToolAuthors({
+      author: 'Burke Holland, James Montemagno',
+      author_github: 'burkeholland,jamesmontemagno',
+    });
+
+    expect(burke).toEqual({ name: 'Burke Holland', github: 'burkeholland' });
+    expect(james).toEqual({ name: 'James Montemagno', github: 'jamesmontemagno' });
+    expect(formatToolAuthors({
+      author: 'Burke Holland, James Montemagno',
+      author_github: 'burkeholland,jamesmontemagno',
+    })).toBe('Burke Holland (@burkeholland), James Montemagno (@jamesmontemagno)');
+
+    const authors = buildAuthors([
+      tool('resize.md', {
+        name: 'ResizeMe',
+        author: 'Burke Holland, James Montemagno',
+        author_github: 'burkeholland,jamesmontemagno',
+        tags: ['windows'],
+        language: 'Swift & Go',
+        date_added: '2026-06-28',
+      }),
+    ]);
+
+    expect(authors.map(author => author.github).sort()).toEqual(['burkeholland', 'jamesmontemagno']);
+    expect(authors.find(author => author.github === 'burkeholland')?.name).toBe('Burke Holland');
+    expect(authors.find(author => author.github === 'burkeholland')?.languages).toEqual([{ name: 'Swift & Go', count: 1 }]);
+    expect(authors.find(author => author.github === 'jamesmontemagno')?.tools[0].data.name).toBe('ResizeMe');
   });
 
   it('builds concrete fallback intros from aggregated tool data', () => {

--- a/src/lib/__tests__/authors.test.ts
+++ b/src/lib/__tests__/authors.test.ts
@@ -90,6 +90,18 @@ describe('author helpers', () => {
     expect(authors.find(author => author.github === 'jamesmontemagno')?.tools[0].data.name).toBe('ResizeMe');
   });
 
+  it('preserves comma-delimited display names for a single organization handle', () => {
+    expect(getToolAuthors({
+      author: 'Aymen, Tamas, Sanjay',
+      author_github: 'microsoft',
+    })).toEqual([{ name: 'Aymen, Tamas, Sanjay', github: 'microsoft' }]);
+
+    expect(formatToolAuthors({
+      author: 'Aymen, Tamas, Sanjay',
+      author_github: 'microsoft',
+    })).toBe('Aymen, Tamas, Sanjay (@microsoft)');
+  });
+
   it('builds concrete fallback intros from aggregated tool data', () => {
     const [author] = buildAuthors([
       tool('timer.md', {

--- a/src/lib/author-utils.js
+++ b/src/lib/author-utils.js
@@ -1,0 +1,28 @@
+export function splitCommaDelimited(value) {
+  return (value || '').split(',').map(part => part.trim()).filter(Boolean);
+}
+
+export function normalizeGitHubHandle(handle) {
+  return (handle || '').trim().replace(/^@+/, '').toLowerCase();
+}
+
+export function extractPrimaryHandle(handle) {
+  return splitCommaDelimited(handle)[0] || '';
+}
+
+export function getToolAuthors(data) {
+  const names = splitCommaDelimited(data.author);
+  const handles = splitCommaDelimited(data.author_github).map(normalizeGitHubHandle).filter(Boolean);
+  const authors = [];
+
+  for (let i = 0; i < handles.length; i++) {
+    const github = handles[i];
+
+    authors.push({
+      github,
+      name: names[i] || github,
+    });
+  }
+
+  return authors;
+}

--- a/src/lib/author-utils.js
+++ b/src/lib/author-utils.js
@@ -11,8 +11,8 @@ export function extractPrimaryHandle(handle) {
 }
 
 export function getToolAuthors(data) {
-  const names = splitCommaDelimited(data.author);
   const handles = splitCommaDelimited(data.author_github).map(normalizeGitHubHandle).filter(Boolean);
+  const names = handles.length > 1 ? splitCommaDelimited(data.author) : [(data.author || '').trim()].filter(Boolean);
   const authors = [];
 
   for (let i = 0; i < handles.length; i++) {

--- a/src/lib/authors.ts
+++ b/src/lib/authors.ts
@@ -1,4 +1,5 @@
 import type { CollectionEntry } from 'astro:content';
+import { extractPrimaryHandle, getToolAuthors, normalizeGitHubHandle, splitCommaDelimited } from './author-utils.js';
 
 export type ToolEntry = CollectionEntry<'tools'>;
 
@@ -16,6 +17,16 @@ export interface AuthorSummary {
   languages: CountedValue[];
   latestDateAdded: string;
   latestTool: ToolEntry;
+}
+
+export interface ToolAuthor {
+  name: string;
+  github: string;
+}
+
+export interface ToolAuthorData {
+  author: string;
+  author_github: string;
 }
 
 export interface AuthorProfileSection {
@@ -77,35 +88,44 @@ export const customAuthorProfiles: Record<string, AuthorProfile> = {
   },
 };
 
-export function normalizeGitHubHandle(handle: string): string {
-  return handle.trim().replace(/^@+/, '').toLowerCase();
-}
+export { getToolAuthors, normalizeGitHubHandle, splitCommaDelimited };
 
 export function getAuthorPath(handle: string): string {
-  return `/authors/${normalizeGitHubHandle(handle)}/`;
+  return `/authors/${normalizeGitHubHandle(extractPrimaryHandle(handle))}/`;
 }
 
 export function getAvatarUrl(handle: string, size = 96): string {
-  return `https://avatars.githubusercontent.com/${normalizeGitHubHandle(handle)}?s=${size}`;
+  return `https://avatars.githubusercontent.com/${normalizeGitHubHandle(extractPrimaryHandle(handle))}?s=${size}`;
 }
 
 export function slugForTool(tool: ToolEntry): string {
   return tool.id.replace(/\.md$/, '');
 }
 
+export function formatToolAuthors(data: ToolAuthorData): string {
+  const authors = getToolAuthors(data);
+  if (authors.length === 0) return data.author;
+  return authors.map(author => `${author.name} (@${author.github})`).join(', ');
+}
+
 export function buildAuthors(tools: ToolEntry[]): AuthorSummary[] {
   const groups = new Map<string, ToolEntry[]>();
+  const authorNames = new Map<string, string[]>();
 
   for (const tool of tools) {
-    const github = normalizeGitHubHandle(tool.data.author_github);
-    if (!github) continue;
-    const group = groups.get(github) || [];
-    group.push(tool);
-    groups.set(github, group);
+    for (const toolAuthor of getToolAuthors(tool.data)) {
+      const group = groups.get(toolAuthor.github) || [];
+      group.push(tool);
+      groups.set(toolAuthor.github, group);
+
+      const names = authorNames.get(toolAuthor.github) || [];
+      names.push(toolAuthor.name);
+      authorNames.set(toolAuthor.github, names);
+    }
   }
 
   return [...groups.entries()]
-    .map(([github, authorTools]) => buildAuthorSummary(github, authorTools))
+    .map(([github, authorTools]) => buildAuthorSummary(github, authorTools, authorNames.get(github) || []))
     .sort((a, b) =>
       b.toolCount - a.toolCount
       || a.name.localeCompare(b.name)
@@ -122,7 +142,7 @@ export function buildAuthorIntro(author: AuthorSummary): string {
   return `${author.name} has shared ${author.toolCount} ${pluralize('tiny tool', author.toolCount)} here${tagText}.${languageText}`;
 }
 
-function buildAuthorSummary(github: string, tools: ToolEntry[]): AuthorSummary {
+function buildAuthorSummary(github: string, tools: ToolEntry[], names: string[]): AuthorSummary {
   const sortedTools = [...tools].sort((a, b) =>
     b.data.date_added.localeCompare(a.data.date_added)
     || a.data.name.localeCompare(b.data.name)
@@ -131,7 +151,7 @@ function buildAuthorSummary(github: string, tools: ToolEntry[]): AuthorSummary {
 
   return {
     github,
-    name: chooseCanonicalName(tools),
+    name: chooseCanonicalName(github, tools, names),
     tools: sortedTools,
     toolCount: tools.length,
     tags: countValues(tools.flatMap(tool => tool.data.tags)),
@@ -141,8 +161,17 @@ function buildAuthorSummary(github: string, tools: ToolEntry[]): AuthorSummary {
   };
 }
 
-function chooseCanonicalName(tools: ToolEntry[]): string {
-  return countValues(tools.map(tool => tool.data.author))[0]?.name || tools[0]?.data.author || 'Unknown author';
+function chooseCanonicalName(github: string, tools: ToolEntry[], names: string[]): string {
+  const frequentName = countValues(names)[0]?.name;
+  if (frequentName) return frequentName;
+
+  const firstTool = tools[0];
+  if (firstTool) {
+    const firstToolAuthorName = getToolAuthors(firstTool.data).find(author => author.github === github)?.name;
+    if (firstToolAuthorName) return firstToolAuthorName;
+  }
+
+  return firstTool?.data.author || 'Unknown author';
 }
 
 function countValues(values: string[]): CountedValue[] {

--- a/src/pages/rss.xml.ts
+++ b/src/pages/rss.xml.ts
@@ -2,6 +2,7 @@ import rss from '@astrojs/rss';
 import { getCollection } from 'astro:content';
 import type { APIContext } from 'astro';
 import { getToolReleaseLink } from '../lib/github';
+import { formatToolAuthors } from '../lib/authors';
 
 export async function GET(context: APIContext) {
   const allTools = await getCollection('tools');
@@ -48,7 +49,7 @@ export async function GET(context: APIContext) {
 
       // Metadata footer
       parts.push('');
-      parts.push(`By ${tool.data.author} (@${tool.data.author_github})`);
+      parts.push(`By ${formatToolAuthors(tool.data)}`);
       if (tool.data.language) parts.push(`Language: ${tool.data.language}`);
       if (tool.data.license) parts.push(`License: ${tool.data.license}`);
       parts.push(`GitHub: ${tool.data.github_url}`);

--- a/src/pages/rss/[platform].xml.ts
+++ b/src/pages/rss/[platform].xml.ts
@@ -2,6 +2,7 @@ import rss from '@astrojs/rss';
 import { getCollection } from 'astro:content';
 import type { APIContext } from 'astro';
 import { getToolReleaseLink } from '../../lib/github';
+import { formatToolAuthors } from '../../lib/authors';
 
 type Platform = {
   slug: string;
@@ -67,7 +68,7 @@ export async function GET(context: APIContext) {
       }
 
       parts.push('');
-      parts.push(`By ${tool.data.author} (@${tool.data.author_github})`);
+      parts.push(`By ${formatToolAuthors(tool.data)}`);
       if (tool.data.language) parts.push(`Language: ${tool.data.language}`);
       if (tool.data.license) parts.push(`License: ${tool.data.license}`);
       parts.push(`GitHub: ${tool.data.github_url}`);

--- a/src/pages/rss/authors/[github].xml.ts
+++ b/src/pages/rss/authors/[github].xml.ts
@@ -1,7 +1,7 @@
 import rss from '@astrojs/rss';
 import { getCollection } from 'astro:content';
 import type { APIContext } from 'astro';
-import { buildAuthorIntro, buildAuthors, slugForTool, type AuthorSummary } from '../../../lib/authors';
+import { buildAuthorIntro, buildAuthors, formatToolAuthors, slugForTool, type AuthorSummary } from '../../../lib/authors';
 import { getToolReleaseLink } from '../../../lib/github';
 
 export async function getStaticPaths() {
@@ -32,7 +32,7 @@ export async function GET(context: APIContext) {
 
       parts.push(tool.data.tagline);
       parts.push('');
-      parts.push(`By ${tool.data.author} (@${tool.data.author_github})`);
+      parts.push(`By ${formatToolAuthors(tool.data)}`);
       if (tool.data.language) parts.push(`Language: ${tool.data.language}`);
       if (tool.data.license) parts.push(`License: ${tool.data.license}`);
       parts.push(`GitHub: ${tool.data.github_url}`);

--- a/src/pages/tools/[slug].astro
+++ b/src/pages/tools/[slug].astro
@@ -4,7 +4,7 @@ import Header from '../../components/Header.astro';
 import Footer from '../../components/Footer.astro';
 import { getCollection, render } from 'astro:content';
 import { getGitHubRepo, getToolReleaseLink } from '../../lib/github';
-import { getAuthorPath, getAvatarUrl } from '../../lib/authors';
+import { getAuthorPath, getAvatarUrl, getToolAuthors } from '../../lib/authors';
 import { existsSync } from 'node:fs';
 import { join } from 'node:path';
 
@@ -20,7 +20,7 @@ const { tool } = Astro.props;
 const { Content } = await render(tool);
 const repo = getGitHubRepo(tool.data.github_url);
 const slug = tool.id.replace(/\.md$/, '');
-const authorPath = getAuthorPath(tool.data.author_github);
+const authors = getToolAuthors(tool.data);
 const releaseLink = getToolReleaseLink(tool.data);
 
 function stripMarkdown(markdown: string) {
@@ -85,17 +85,19 @@ const ogImage = hasSocialCard ? `/social/${slug}.png` : undefined;
           <p class="tool-tagline">{tool.data.tagline}</p>
 
           <div class="tool-meta">
-            <div class="tool-author">
-              <img
-                src={getAvatarUrl(tool.data.author_github, 40)}
-                alt={tool.data.author}
-                class="author-avatar"
-                loading="lazy"
-                decoding="async"
-              />
-              <div>
-                <a href={authorPath} class="author-name">{tool.data.author}</a>
-              </div>
+            <div class="tool-authors">
+              {authors.map((toolAuthor) => (
+                <a href={getAuthorPath(toolAuthor.github)} class="tool-author">
+                  <img
+                    src={getAvatarUrl(toolAuthor.github, 40)}
+                    alt={toolAuthor.name}
+                    class="author-avatar"
+                    loading="lazy"
+                    decoding="async"
+                  />
+                  <span class="author-name">{toolAuthor.name}</span>
+                </a>
+              ))}
             </div>
 
             <div class="tool-badges">
@@ -253,10 +255,19 @@ const ogImage = hasSocialCard ? `/social/${slug}.png` : undefined;
     margin-bottom: 1rem;
   }
 
+  .tool-authors {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+  }
+
   .tool-author {
     display: flex;
     align-items: center;
     gap: 0.75rem;
+    color: var(--color-text);
+    text-decoration: none;
   }
 
   .author-avatar {


### PR DESCRIPTION
Implement functionality to handle multiple authors for tools, including updates to author formatting and display. This change enhances the author data structure and improves the presentation of author information throughout the application.

Fixes #608

https://github.com/user-attachments/assets/d62ec3f2-0b24-4e5d-b76a-b927051f8a5a

