### PR TITLE
Add 7 claimed author pages

### DIFF
--- a/src/content/authors/abnersajr.md
+++ b/src/content/authors/abnersajr.md
@@ -1,0 +1,6 @@
+---
+github: "abnersajr"
+name: "Abner Soares Alves Junior"
+headline: "Brazilian Software Developer, based in Montreal 🇧🇷 🇨🇦"
+---
+Working with different programming languages. Creating small tools here and there for personal needs.

--- a/src/content/authors/byggarepop.md
+++ b/src/content/authors/byggarepop.md
@@ -1,0 +1,11 @@
+---
+github: "byggarepop"
+name: "Byggarepop"
+headline: "Tools that improve how agents spend tokens and navigate codebases."
+links:
+  - label: "LinkedIn"
+    url: "https://www.linkedin.com/in/sebastian-larsson-65929382/"
+  - label: "Tokensaver"
+    url: "https://tokensavermcp.com/"
+---
+I'm a .NET developer that enjoy building small, focused tools — Tokensaver, McpOrchestrator, and Unwritten. I think agents should read less, guess less, and follow the conventions your codebase never wrote down.

--- a/src/content/authors/casablanque-code.md
+++ b/src/content/authors/casablanque-code.md
@@ -1,0 +1,6 @@
+---
+github: "casablanque-code"
+name: "Andrew"
+headline: "Engineer building open-source projects."
+---
+I'm an engineer who enjoys understanding how systems work beneath the surface. I build open-source software, explore networking, security, and infrastructure, and occasionally write about the things I learn along the way.

--- a/src/content/authors/cdilorenzo.md
+++ b/src/content/authors/cdilorenzo.md
@@ -1,0 +1,12 @@
+---
+github: "cdilorenzo"
+name: "Claudio Di Lorenzo"
+headline: "Small Windows tools for developers, built with C#, AI, and a bit of humor."
+website_url: "https://github.com/cdilorenzo"
+links:
+  - label: "LinkedIn"
+    url: "https://www.linkedin.com/in/claudio-di-lorenzo-96345695"
+---
+I'm a Berlin-based C#/.NET developer who likes building small, focused tools that make everyday developer pain a little more visible, useful, or funny.
+
+My tiny tools usually start from a very specific itch: something I noticed while coding, working with AI tools, or dealing with developer workflows. I like keeping them lightweight, local-first, and simple enough to understand at a glance.

--- a/src/content/authors/mikewilliams-uk.md
+++ b/src/content/authors/mikewilliams-uk.md
@@ -1,0 +1,7 @@
+---
+github: "MikeWilliams-UK"
+name: "Mike Williams"
+headline: "I love to write small tools that will do boring repetitive tasks for me."
+website_url: "http://www.doublewide.co.uk"
+---
+I have been programming in C# and SQL (Oracle and SQL Server) since early 1990. My programming life started during my technical college years in late 1970's with hand coded 6502 Assembly code, entered on a hex keypad. I currently help maintain [Chem4Word](https://github.com/Chem4Word).

--- a/src/content/authors/petrroll.md
+++ b/src/content/authors/petrroll.md
@@ -1,0 +1,10 @@
+---
+github: "petrroll"
+name: "Petr Houška"
+headline: "Useful tools of any nature :)"
+website_url: "http://petrroll.cz"
+links:
+  - label: "Twitter"
+    url: "https://x.com/Petrroll"
+---
+Tiny tools, mostly agent-generated, but usually polished as I don't like rough edges :)

--- a/src/content/authors/yusufk.md
+++ b/src/content/authors/yusufk.md
@@ -1,0 +1,12 @@
+---
+github: "yusufk"
+name: "Yusuf Kaka"
+headline: "Random experiments, ideas, learnings and vibes"
+website_url: "https://yusuf.kaka.co.za"
+links:
+  - label: "Bluesky"
+    url: "https://bsky.app/profile/yusufk.co.za"
+---
+Engineer, which by definition, means that I will struggle compiling a socially attractive bio.
+
+African. Muslim. Tinkerer.


### PR DESCRIPTION
Processes the following verified author claims:

- Closes #683 (@yusufk — Yusuf Kaka)
- Closes #677 (@petrroll — Petr Houška)
- Closes #668 (@byggarepop — Byggarepop)
- Closes #664 (@abnersajr — Abner Soares Alves Junior)
- Closes #652 (@cdilorenzo — Claudio Di Lorenzo)
- Closes #651 (@MikeWilliams-UK — Mike Williams)
- Closes #643 (@casablanque-code — Andrew)

All claims had `claim-verified` label (bot confirmed GitHub account match). Author pages generated from submitted info.