### PR TITLE
Add author claim triage + auto-process workflows

### DIFF
--- a/.github/workflows/process-author-claim.yml
+++ b/.github/workflows/process-author-claim.yml
@@ -1,0 +1,96 @@
+name: Process Author Page Claim
+
+on:
+  issues:
+    types: [labeled]
+
+permissions:
+  issues: write
+  contents: write
+
+jobs:
+  process:
+    name: Write author MD file and close issue
+    runs-on: ubuntu-latest
+    if: github.event.label.name == 'queued-author'
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Write author file and close issue
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const { execSync } = require('child_process');
+            const fs = require('fs');
+            const path = require('path');
+
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const issue = context.payload.issue;
+            const body = issue.body || '';
+
+            function getField(md, label) {
+              const escaped = label.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+              const re = new RegExp(`###\\s+${escaped}\\s*\\n+([\\s\\S]*?)(?=\\n###\\s+|$)`, 'i');
+              const m = md.match(re);
+              if (!m) return '';
+              return m[1].replace(/<!--[\s\S]*?-->/g, '').replace(/^_No response_$/gim, '').trim();
+            }
+
+            function parseLinks(raw) {
+              if (!raw) return [];
+              return raw.split(/\r?\n/).map(l => l.trim()).filter(Boolean).map(l => {
+                const m = l.match(/^(.+?)\s*[-–]\s*(https?:\/\/.+)$/);
+                return m ? { label: m[1].trim(), url: m[2].trim() } : null;
+              }).filter(Boolean);
+            }
+
+            const github_handle = getField(body, 'GitHub username for this author page')
+              .split(/\r?\n/)[0].trim().replace(/^@/, '').toLowerCase();
+
+            if (!github_handle) {
+              core.setFailed('Could not parse GitHub handle from issue body.');
+              return;
+            }
+
+            const name        = getField(body, 'Display name');
+            const headline    = getField(body, 'Short headline');
+            const bio         = getField(body, 'Bio / intro');
+            const website_url = getField(body, 'Website URL (optional)');
+            const linksRaw    = getField(body, 'Other links (optional)');
+            const links       = parseLinks(linksRaw);
+
+            const lines = ['---', `github: "${github_handle}"`];
+            if (name)        lines.push(`name: "${name}"`);
+            if (headline)    lines.push(`headline: "${headline.replace(/"/g, '\\"')}"`);
+            if (website_url) lines.push(`website_url: "${website_url}"`);
+            if (links.length) {
+              lines.push('links:');
+              for (const l of links) {
+                lines.push(`  - label: "${l.label}"`);
+                lines.push(`    url: "${l.url}"`);
+              }
+            }
+            lines.push('---');
+            if (bio) lines.push(bio);
+
+            const mdContent = lines.join('\n') + '\n';
+            const filePath = path.join('src', 'content', 'authors', `${github_handle}.md`);
+
+            fs.writeFileSync(filePath, mdContent, 'utf8');
+
+            execSync('git config user.email "actions@github.com"');
+            execSync('git config user.name "GitHub Actions"');
+            execSync(`git add ${filePath}`);
+            execSync(`git commit -m "Add claimed author page for @${github_handle} (closes #${issue.number})"`);
+            execSync('git push');
+
+            await github.rest.issues.createComment({
+              owner, repo, issue_number: issue.number,
+              body: `✅ Author page for @${github_handle} has been added! It will be live at https://www.tinytooltown.com/authors/${github_handle}/ once the site rebuilds.\n\nThanks for being part of Tiny Tool Town! 🏘️`,
+            });
+
+            await github.rest.issues.update({
+              owner, repo, issue_number: issue.number, state: 'closed',
+            });

--- a/.github/workflows/triage-author-claim.yml
+++ b/.github/workflows/triage-author-claim.yml
@@ -1,0 +1,100 @@
+name: Triage Author Page Claim
+
+on:
+  issues:
+    types: [labeled]
+
+permissions:
+  issues: write
+  contents: read
+
+jobs:
+  triage:
+    name: Surface author claim for maintainer review
+    runs-on: ubuntu-latest
+    if: github.event.label.name == 'claim-verified'
+
+    steps:
+      - name: Post triage summary
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const issue = context.payload.issue;
+            const body = issue.body || '';
+
+            const marker = '<!-- author-claim-triage -->';
+            const existing = await github.paginate(github.rest.issues.listComments, {
+              owner, repo, issue_number: issue.number, per_page: 100,
+            });
+            if (existing.some(c => c.body?.includes(marker))) return;
+
+            function getField(md, label) {
+              const escaped = label.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+              const re = new RegExp(`###\\s+${escaped}\\s*\\n+([\\s\\S]*?)(?=\\n###\\s+|$)`, 'i');
+              const m = md.match(re);
+              if (!m) return '';
+              return m[1].replace(/<!--[\s\S]*?-->/g, '').replace(/^_No response_$/gim, '').trim();
+            }
+
+            function parseLinks(raw) {
+              if (!raw) return [];
+              return raw.split(/\r?\n/).map(l => l.trim()).filter(Boolean).map(l => {
+                const m = l.match(/^(.+?)\s*[-–]\s*(https?:\/\/.+)$/);
+                return m ? { label: m[1].trim(), url: m[2].trim() } : null;
+              }).filter(Boolean);
+            }
+
+            const github_handle = getField(body, 'GitHub username for this author page')
+              .split(/\r?\n/)[0].trim().replace(/^@/, '').toLowerCase();
+            const name        = getField(body, 'Display name');
+            const headline    = getField(body, 'Short headline');
+            const bio         = getField(body, 'Bio / intro');
+            const website_url = getField(body, 'Website URL (optional)');
+            const linksRaw    = getField(body, 'Other links (optional)');
+            const notes       = getField(body, 'Notes or highlights (optional)');
+            const links       = parseLinks(linksRaw);
+
+            // Build proposed MD content
+            const frontmatter = [
+              '---',
+              `github: "${github_handle}"`,
+              name       ? `name: "${name}"` : null,
+              headline   ? `headline: "${headline.replace(/"/g, '\\"')}"` : null,
+              website_url ? `website_url: "${website_url}"` : null,
+              links.length ? `links:\n${links.map(l => `  - label: "${l.label}"\n    url: "${l.url}"`).join('\n')}` : null,
+              '---',
+            ].filter(Boolean).join('\n');
+
+            const mdContent = bio ? `${frontmatter}\n${bio}` : frontmatter;
+
+            const previewBlock = '```markdown\n' + mdContent + '\n```';
+
+            const comment = [
+              marker,
+              `## 👤 Author Claim Triage — @${github_handle}`,
+              '',
+              '| Field | Value |',
+              '|-------|-------|',
+              `| **GitHub** | @${github_handle} |`,
+              name       ? `| **Display name** | ${name} |` : null,
+              headline   ? `| **Headline** | ${headline} |` : null,
+              website_url ? `| **Website** | ${website_url} |` : null,
+              links.length ? `| **Links** | ${links.map(l => `[${l.label}](${l.url})`).join(', ')} |` : null,
+              notes      ? `| **Notes** | ${notes.replace(/\n/g, ' ')} |` : null,
+              '',
+              '### Proposed `src/content/authors/' + github_handle + '.md`',
+              previewBlock,
+              '',
+              '---',
+              `**@${owner}** — add \`queued-author\` to approve, or close to reject.`,
+            ].filter(l => l !== null).join('\n');
+
+            await github.rest.issues.createComment({
+              owner, repo, issue_number: issue.number, body: comment,
+            });
+
+            await github.rest.issues.addLabels({
+              owner, repo, issue_number: issue.number, labels: ['needs-maintainer-review'],
+            }).catch(() => {});


### PR DESCRIPTION
Adds the missing automation for author page claims, matching the same human-in-the-loop pattern as tool triage.

## Flow

1. Author opens a claim issue (already working ✅)
2. `validate-author-claim.yml` verifies identity → adds `claim-verified` (already working ✅)
3. **NEW:** `triage-author-claim.yml` fires on `claim-verified` → parses the form → posts a triage comment with the proposed `src/content/authors/<username>.md` preview + adds `needs-maintainer-review`
4. **NEW:** Maintainer (Scott) reviews and adds `queued-author` to approve
5. **NEW:** `process-author-claim.yml` fires on `queued-author` → writes the MD file → commits to main → posts welcome comment → closes the issue

## Same vibe as tool triage
Bot does the legwork. Maintainer makes the call. No author page goes live without explicit approval.