### PR TITLE
Add zoxide-doctor

### DIFF
--- a/src/content/tools/zoxide-doctor.md
+++ b/src/content/tools/zoxide-doctor.md
@@ -1,0 +1,18 @@
+---
+name: "zoxide-doctor"
+tagline: "A zero-dependency checkup for zoxide, PATH, and shell initialization."
+author: "LTD Atlas"
+author_github: "jiankn"
+github_url: "https://github.com/jiankn/zoxide-doctor"
+website_url: "https://zoxide.org/tools/zoxide-doctor/"
+tags: ["cli", "shell", "linux", "developer-tools", "diagnostics", "zoxide"]
+language: "JavaScript"
+license: "MIT"
+date_added: "2026-08-06"
+featured: false
+theme: "terminal"
+---
+
+zoxide-doctor explains why an installed zoxide setup is not working. It checks whether the binary is on PATH, verifies `zoxide init` for the selected shell, looks for active initialization in common profile files, reports optional fzf availability, and can emit machine-readable JSON. The tool is read-only, has no runtime dependencies, and runs on Linux, macOS, and Windows.
+
+This is an independent community tool, not an official zoxide project.

--- a/src/content/tools/zoxide-doctor.md
+++ b/src/content/tools/zoxide-doctor.md
@@ -13,6 +13,6 @@ featured: false
 theme: "terminal"
 ---
 
-zoxide-doctor explains why an installed zoxide setup is not working. It checks whether the binary is on PATH, verifies `zoxide init` for the selected shell, looks for active initialization in common profile files, reports optional fzf availability, and can emit machine-readable JSON. The tool is read-only, has no runtime dependencies, and runs on Linux, macOS, and Windows.
+zoxide-doctor explains why an installed zoxide setup is not working. It checks whether the binary is on PATH, verifies `zoxide init` for the selected shell, looks for active initialization in common profile files, reports optional fzf availability, and can emit machine-readable JSON. The tool is read-only, has no runtime dependencies, and runs on Linux, macOS, and Windows. Its results can be compared with the expected behavior in the [zoxide commands reference](https://zoxide.org/blog/zoxide-commands/).
 
 This is an independent community tool, not an official zoxide project.


### PR DESCRIPTION
## What this adds

Adds `zoxide-doctor`, a free, zero-dependency CLI that diagnoses zoxide PATH and shell-initialization problems without modifying local configuration.

- Public MIT-licensed repository with README
- Local, read-only checks
- JSON and non-interactive output
- Linux, macOS, and Windows support
- Independent community tool; not presented as official zoxide software
- Contextual command-reference link for interpreting diagnostic results

## Validation

- `npm ci`
- `npm test` — 51 tests passed
- `npm run build` — generated `/tools/zoxide-doctor/` successfully
- Generated HTML contains a plain followable `zoxide commands reference` link