### PR TITLE
Add tags to promptring tool entry

### DIFF
--- a/src/content/tools/promptring.md
+++ b/src/content/tools/promptring.md
@@ -5,7 +5,7 @@ author: "Pratyansh Agrawal"
 author_github: "pratyansh-agrawal"
 github_url: "https://github.com/pratyansh-agrawal/promptring"
 thumbnail: "/thumbnails/promptring.gif"
-tags: []
+tags: ["notification", "productivity", "cross-platform", "macos", "windows"]
 language: "Python"
 license: "MIT"
 date_added: "2026-06-22"


### PR DESCRIPTION
## What

The `promptring` tool entry has an empty `tags: []` array, so it doesn't surface in any tag-based browsing or filtering. This adds five tags that describe the tool:

`notification`, `productivity`, `cross-platform`, `macos`, `windows`

## Notes

- Only `src/content/tools/promptring.md` is touched — a single line change.
- Five tags, matching the `max 5, lowercase` guidance in `.github/copilot-instructions.md`.
- Tags follow the existing lowercase, inline-array convention used by other entries.
- `ai_summary` / `ai_features` were left untouched, per CONTRIBUTING.md.
- I'm the author of promptring (`author_github: pratyansh-agrawal`).

## Validation

Ran the checks from CONTRIBUTING.md on Node 24:

- `npm ci` — clean
- `npm test` — 57 tests passed (5 files)
- `npm run build` — 956 pages built successfully

Confirmed all five tags render as filter links on the generated `/tools/promptring/` page.