### PR TITLE
chore(feat): Allow deselecting the active tag filter on the browse page

### DIFF
--- a/src/pages/tools/index.astro
+++ b/src/pages/tools/index.astro
@@ -71,16 +71,16 @@ const moreTags = [...tagCounts.entries()]
         <button class="sort-btn favorites-only-btn" id="favorites-only-btn" aria-pressed="false">❤ Favorites only</button>
       </div>
       <div class="tags-filter" id="tags-filter">
-        <button class="tag-btn active" data-tag="all">All</button>
+        <button class="tag-btn active" data-tag="all" aria-pressed="true">All</button>
         {popularTags.map(tag => (
-          <button class="tag-btn" data-tag={tag}>{tag} <span class="tag-count">{tagCounts.get(tag)}</span></button>
+          <button class="tag-btn" data-tag={tag} aria-pressed="false">{tag} <span class="tag-count">{tagCounts.get(tag)}</span></button>
         ))}
         {moreTags.length > 0 && (
           <button class="tag-btn more-tags-toggle" id="more-tags-toggle">More ▾</button>
         )}
         <div class="more-tags" id="more-tags" style="display: none;">
           {moreTags.map(tag => (
-            <button class="tag-btn" data-tag={tag}>{tag}</button>
+            <button class="tag-btn" data-tag={tag} aria-pressed="false">{tag}</button>
           ))}
         </div>
       </div>
@@ -185,6 +185,26 @@ const moreTags = [...tagCounts.entries()]
       url.searchParams.delete('favorites');
     }
 
+    history.replaceState(null, '', url.toString());
+  }
+
+  function setActiveTag(tag: string): void {
+    activeTag = tag;
+
+    document.querySelectorAll('.tag-btn[data-tag]').forEach(b => {
+      const isActive = (b as HTMLElement).dataset.tag === activeTag;
+      b.classList.toggle('active', isActive);
+      b.setAttribute('aria-pressed', String(isActive));
+    });
+  }
+
+  // Only touches the URL when a ?tag= is actually present, so tags picked by
+  // clicking (which never write to the URL) leave it untouched.
+  function clearTagParam(): void {
+    const url = new URL(window.location.href);
+    if (!url.searchParams.has('tag')) return;
+
+    url.searchParams.delete('tag');
     history.replaceState(null, '', url.toString());
   }
 
@@ -307,24 +327,17 @@ const moreTags = [...tagCounts.entries()]
     search.value = urlQ;
     filterTools();
   } else if (urlTag) {
-    activeTag = urlTag.toLowerCase();
-    // Activate the matching tag button (may be in the "more" section)
-    if (moreTags && moreToggle) {
-      const allBtns = document.querySelectorAll('.tag-btn[data-tag]');
-      let found = false;
-      allBtns.forEach(b => {
-        if ((b as HTMLElement).dataset.tag === activeTag) {
-          found = true;
-          // If it's inside the hidden more-tags section, expand it
-          if (b.closest('#more-tags')) {
-            moreTags.style.display = 'contents';
-            moreToggle.textContent = 'Less ▴';
-          }
-          document.querySelectorAll('.tag-btn').forEach(x => x.classList.remove('active'));
-          b.classList.add('active');
-        }
-      });
+    // Unknown tags still apply, so a stale ?tag= shows the empty state rather
+    // than silently listing everything.
+    setActiveTag(urlTag.toLowerCase());
+
+    // If the matching button lives in the hidden "more" section, expand it
+    const activeBtn = document.querySelector('.tag-btn[data-tag].active');
+    if (activeBtn?.closest('#more-tags') && moreTags && moreToggle) {
+      moreTags.style.display = 'contents';
+      moreToggle.textContent = 'Less ▴';
     }
+
     filterTools();
   }
 
@@ -341,9 +354,14 @@ const moreTags = [...tagCounts.entries()]
   document.getElementById('tags-filter')!.addEventListener('click', (e) => {
     const btn = (e.target as HTMLElement).closest('.tag-btn:not(.more-tags-toggle)') as HTMLElement;
     if (!btn || !btn.dataset.tag) return;
-    document.querySelectorAll('.tag-btn').forEach(b => b.classList.remove('active'));
-    btn.classList.add('active');
-    activeTag = btn.dataset.tag;
+
+    // Clicking the active tag again clears it and falls back to "All". The
+    // 'all' guard keeps a click on an already-active "All" a no-op.
+    const clicked = btn.dataset.tag;
+    const deselecting = clicked !== 'all' && clicked === activeTag;
+
+    setActiveTag(deselecting ? 'all' : clicked);
+    if (deselecting) clearTagParam();
     filterTools();
   });
 


### PR DESCRIPTION
## Problem

On `/tools`, tag chips are select-only. Once you pick a tag, the only ways back to the full list are clicking **All** or reloading the page — clicking the active chip just re-selects it.

The handler in `src/pages/tools/index.astro` unconditionally activated whatever was clicked:

```js
document.querySelectorAll('.tag-btn').forEach(b => b.classList.remove('active'));
btn.classList.add('active');
activeTag = btn.dataset.tag;
```

## Fix

Clicking the already-active chip now resets to `all` and restores every result. Single-select is unchanged — **multi-select is intentionally out of scope**.

- `setActiveTag()` centralises the active-class + `aria-pressed` sync that was duplicated between the click handler and the `?tag=` load path.
- Toggle-off triggers only when the clicked tag is already active, with an `all` guard so clicking **All** while active stays a no-op.
- Tag chips gain `aria-pressed`, matching the existing sort buttons, so the toggle state is announced to assistive tech.

### URL handling

Tag clicks never wrote to the URL (only `sort` and `favorites` do), while `?tag=` is an inbound deep link from `tools/[slug].astro` and `authors/[github].astro`. That split meant a deselect could be undone by a refresh.

`clearTagParam()` removes `?tag=` **only when it is present**, so deep-linked filters stay off after refresh while click-chosen tags leave a clean URL untouched. Other params such as `sort` are preserved.

### Drive-by fix

The `?tag=` load path nested chip activation inside `if (moreTags && moreToggle)`. The `#more-tags` div always renders but `More ▾` is conditional on `moreTags.length > 0`, so if every tag were popular (3+ uses) `moreToggle` would be `null` and no chip would highlight despite the filter applying. Routing through `setActiveTag()` removes that coupling. Unknown-tag behaviour is preserved — a stale `?tag=` still shows the empty state rather than silently listing everything.

## Validation

`npm ci`, `npm test` (57 passed), `npm run build` (956 pages) on Node 24.

Also drove the built site in headless Chromium — 22/22 checks, no console errors:

- select → filters (567 → 129); re-click → restores 567 with **All** active
- clicking **All** while active is a no-op
- `?tag=cli` deselect clears the param and survives refresh
- click-chosen tags leave the URL clean both ways
- `?tag=cli&sort=oldest` deselect drops `tag`, keeps `sort`
- tags under `More ▾` toggle correctly and the section stays expanded
- composes with search (tag+search 21 → search-only 49)
- unknown `?tag=` still yields the empty state
- `aria-pressed` tracks selection throughout

Scoped to one file; no changes to filtering logic, styling, or unrelated code.