### PR TITLE
Add tags to tvdinner listing

### DIFF
--- a/src/content/tools/tvdinner.md
+++ b/src/content/tools/tvdinner.md
@@ -5,7 +5,7 @@ author: "Iain Smith"
 author_github: "issinoho"
 github_url: "https://github.com/issinoho/tvdinner"
 thumbnail: "/thumbnails/tvdinner.webp"
-tags: ["cli", "iptv", "m3u", "epg", "mpv", "streaming"]
+tags: ["cli", "iptv", "m3u", "epg", "mpv"]
 language: "Python"
 license: "MIT"
 date_added: "2026-08-03"

--- a/src/content/tools/tvdinner.md
+++ b/src/content/tools/tvdinner.md
@@ -5,7 +5,7 @@ author: "Iain Smith"
 author_github: "issinoho"
 github_url: "https://github.com/issinoho/tvdinner"
 thumbnail: "/thumbnails/tvdinner.webp"
-tags: []
+tags: ["cli", "iptv", "m3u", "epg", "mpv", "streaming"]
 language: "Python"
 license: "MIT"
 date_added: "2026-08-03"


### PR DESCRIPTION
tvdinner's listing currently has an empty `tags: []`. Adding tags for discoverability: `cli`, `iptv`, `m3u`, `epg`, `mpv`, `streaming` — matching the existing conventions used by other entries (lowercase, hyphenated where multi-word).

I'm the author (`author_github: issinoho`), so this is a self-edit of my own tool's listing.