### PR TITLE
Remove queued-import label after successful import

### DIFF
--- a/.github/workflows/batch-approve.yml
+++ b/.github/workflows/batch-approve.yml
@@ -611,6 +611,7 @@ jobs:
                   issue_number: item.issueNumber,
                   state: 'closed',
                 });
+                await removeLabelIfExists(item.issueNumber, 'queued-import');
               }
             } else if (processed.length > 0 && !pushed) {
               for (const item of processed) {


### PR DESCRIPTION
## What

One line in `batch-approve.yml`: remove the `queued-import` label on the success path, right after the issue is closed.

## Why

Today a successfully-imported tool ends up **closed but still labeled `queued-import`**. That's the normal success state, but it's indistinguishable from "queued and stuck" when scanning labels — so anyone auditing the queue sees a pile of queued-looking issues and reasonably concludes something jammed.

This is drift, not design. Both sibling paths already clean up after themselves:

- `batch-approve.yml` failure path — `markFailed()` → `removeLabelIfExists(issueNumber, 'queued-import')` (line 178)
- `process-author-claim.yml` — removes `queued-author` + `needs-maintainer-review` before closing (line 74)

Only the tool success path leaves its queue label behind. This makes it match.

## Why it's safe

The queue consumer filters on `state: 'open'` (line 193), so `queued-import` is only ever *read* on open issues. Removing it from an issue that was just closed cannot affect queue processing.

Label lifecycle traced across the repo — no other consumer depends on it persisting after close:

- `triage-tool.yml` → adds `ready-to-approve`
- `approve-tool.yml` → adds `queued-import`, dispatches the importer
- `batch-approve.yml` → drains queue (this PR: now also clears the label on success)

Reuses the existing `removeLabelIfExists()` helper, which already swallows 404s.

## Testing

- `npm test` — 57/57 pass (unchanged from baseline on `main`)
- YAML parses; embedded `github-script` body syntax-checked async-wrapped (top-level `await` is valid in that context)
- No source-text test asserts on the changed lines. `author-claim-parser.test.ts:102-114` pins literals in `process-author-claim.yml` / `validate-author-claim.yml`, both untouched here.

## Deliberately not included

Reviewed but left for separate issues, to keep this reviewable:

1. `process-author-claim.yml` writes the author file unconditionally. A naive existence guard would be **wrong** — `customize-author.yml` advertises "Claim or **update** your maker page", so overwrite is a supported flow. Correct fix needs an explicit approval gate plus idempotent no-op on identical content.
2. Its two `core.setFailed()` paths return before label cleanup, so a failed claim keeps `queued-author` forever and can't self-retry (trigger is `issues: [labeled]`).
3. It has no `concurrency` group and does a bare `git push` — the only main-writer without the `tool-file-writer` group and the 5x pull-rebase retry that `batch-approve.yml` and `refresh-thumbnails.yml` both have.

---
_Authored by Scott's agent on his behalf._