### PR TITLE
Clear stale import-failed when a later import succeeds

### DIFF
--- a/.github/workflows/batch-approve.yml
+++ b/.github/workflows/batch-approve.yml
@@ -626,6 +626,9 @@ jobs:
                   state: 'closed',
                 });
                 await removeLabelIfExists(item.issueNumber, 'queued-import');
+                // A submission that failed an earlier run and was later fixed
+                // would otherwise stay branded import-failed forever.
+                await removeLabelIfExists(item.issueNumber, 'import-failed');
               }
             } else if (processed.length > 0 && !pushed) {
               for (const item of processed) {

--- a/src/lib/__tests__/author-claim-parser.test.ts
+++ b/src/lib/__tests__/author-claim-parser.test.ts
@@ -161,4 +161,9 @@ describe('batch import safety', () => {
     const workflow = readFileSync('.github/workflows/batch-approve.yml', 'utf8');
     expect(workflow).toContain("removeLabelIfExists(item.issueNumber, 'queued-import')");
   });
+
+  it('clears a stale import-failed when a later run succeeds', () => {
+    const workflow = readFileSync('.github/workflows/batch-approve.yml', 'utf8');
+    expect(workflow).toContain("removeLabelIfExists(item.issueNumber, 'import-failed')");
+  });
 });


### PR DESCRIPTION
Same bug class as #757, on the other label.

## The bug

`markFailed()` adds `import-failed` (batch-approve.yml:175), but **nothing removes it when a corrected submission imports on a later run**. A tool that failed once, got fixed by its author, and imported successfully stays branded as failed forever.

`approve-tool.yml` already clears it on re-approve (line 52), so the intent clearly exists — the success path in `batch-approve.yml` just never got the same treatment.

## Evidence

Found while backfilling the `queued-import` residue from #757. Four closed issues carried a stale `import-failed` despite their tool files being live on main:

| Issue | Tool file on `main` |
|---|---|
| #754 | `absolute-humidity-calculator.md` |
| #516 | `onboard.md` |
| #515 | `markdown-editor-js.md` |
| #322 | `bluetoothwave.md` |

#754 is the clearest case:
- Aug 20 22:16 — author: *"I confused the demo url with the repository url. Now they are fixed"*
- Aug 21 05:25 — `⚠️ Import failed: GitHub URL is invalid` (ran against the **pre-fix** URL)
- Aug 23 05:08 — imported successfully, tool live at a 200

Four out of four is a pattern, not a fluke.

## The fix

One `removeLabelIfExists` call on the success path, right beside the `queued-import` removal from #757.

Historical residue on those four issues has already been cleaned up by hand, so this is purely forward-looking.

## Testing

- `npm test` — **65/65** (64 baseline + 1 new regression test)
- YAML parses; embedded `github-script` body syntax-checked async-wrapped

---
_Authored by Scott's agent on his behalf._