### PR TITLE
Update Broadcast listing: Maxine GPU backend, Omarchy plugin, per-window routing

### DIFF
--- a/src/content/tools/broadcast.md
+++ b/src/content/tools/broadcast.md
@@ -1,11 +1,12 @@
 ---
 name: "Broadcast"
-tagline: "AI-powered per-app noise suppression for PipeWire on Linux"
+tagline: "AI-powered per-app noise suppression for PipeWire on Linux — CPU or NVIDIA GPU"
 author: "Gareth Hubball"
 author_github: "londospark"
 github_url: "https://github.com/londospark/broadcast"
+release_url: "https://github.com/londospark/broadcast/releases/latest"
 thumbnail: "/thumbnails/broadcast.webp"
-tags: ["linux", "audio", "noise-suppression", "pipewire", "cli"]
+tags: ["linux", "audio", "noise-suppression", "pipewire", "cli", "gpu", "nvidia", "omarchy"]
 language: "Rust"
 license: "GPL-3.0-or-later"
 theme: "terminal"
@@ -15,8 +16,10 @@ ai_summary: "Say goodbye to background noise ruining your calls or streams with 
 ai_features: ["🤖 AI-driven noise suppression for mic and output audio", "🎛️ Per-app routing control to filter only what you want", "🖥️ Handy CLI and GTK4 GUI for easy toggling and setup", "🔄 Native PipeWire integration with customizable filter chains"]
 ---
 
-Broadcast routes individual application audio streams through DeepFilterNet AI noise suppression on Linux. Instead of filtering everything or nothing, you pick which apps get cleaned up — Discord and browser calls get noise-free audio while Spotify and games stay untouched.
+Broadcast routes individual application audio streams through AI noise suppression on Linux. Instead of filtering everything or nothing, you pick which apps get cleaned up — Discord and browser calls get noise-free audio while Spotify and games stay untouched. Per-window routing works too, so two windows of the same app (say, a YouTube Music tab versus a regular browsing tab) can be routed independently.
 
-Built it because every Linux noise suppression tool is all-or-nothing. I wanted typing noise gone from video calls without mangling my music. It runs on CPU (~3% of one core), so your GPU stays free.
+Built it because every Linux noise suppression tool is all-or-nothing. I wanted typing noise gone from video calls without mangling my music.
 
-Ships as three tiny Rust binaries: a shared library, a CLI for scripting/keybinds, and a GTK4+Libadwaita GUI for toggling per-app routing. Real-time stream detection via PipeWire monitoring, persistent per-app preferences, and one-click toggle from your status bar.
+Two backends: DeepFilterNet on CPU (~3% of one core, any hardware), or NVIDIA's Maxine SDK on an RTX GPU for noticeably better suppression of sharp transients like keyboard clicks. Every release now bundles the Maxine runtime for desktop RTX cards (Turing through Blackwell), so GPU users don't need their own NVIDIA developer account to turn it on.
+
+Ships as CLI and GTK4+Libadwaita GUI binaries (AUR, `.deb`, `.rpm`, or plain download), plus a native [Omarchy](https://omarchy.org) bar-widget plugin for backend switching, health status, and per-app/per-window routing without leaving the bar.


### PR DESCRIPTION
The listing was added back in March and hadn't kept up with the project — updating the tagline, tags, and description to reflect what's changed since:

- An NVIDIA Maxine GPU backend, now bundled in releases so most desktop RTX users don't need their own NGC account
- A native [Omarchy](https://omarchy.org) bar-widget plugin
- Per-window (not just per-app) audio routing
- AUR packages

Also adds `release_url`. Left `ai_summary`/`ai_features` untouched per CONTRIBUTING.md — those are automation-generated.

One more thing worth a maintainer's attention: the repo's README.md previously had no real screenshot (just said "Coming soon"), which I'd guess is why the current thumbnail looks like a generic fallback. It now has a real one, so a `workflow_dispatch` of `refresh-thumbnails.yml` should pick up something better whenever convenient.

Ran `npm ci && npm test && npm run build` locally per CONTRIBUTING.md — 65 tests passing, 982 pages built including `/tools/broadcast/`.