### PR TITLE
Add cpys author profile

### DIFF
--- a/src/content/authors/cpys.md
+++ b/src/content/authors/cpys.md
@@ -1,0 +1,20 @@
+---
+github: "cpys"
+name: "陈玄风"
+headline: "独立开发面向开发者的本地优先桌面工具"
+website_url: "https://cpys.github.io/codex-quota-overlay/"
+links:
+  - label: "Codex Quota Overlay"
+    url: "https://github.com/cpys/codex-quota-overlay"
+  - label: "中文 README"
+    url: "https://github.com/cpys/codex-quota-overlay/blob/main/README.zh-CN.md"
+notes:
+  - "关注把有用的开发者上下文放在桌面上，同时减少不必要的数据采集。"
+  - "Codex Quota Overlay 是独立社区开源项目，与 OpenAI 没有隶属、授权或支持关系。"
+sections:
+  - title: "Developer utilities"
+    description: "面向开发者的本地优先桌面工具。"
+    toolSlugs:
+      - "codex-quota-overlay"
+---
+我维护面向开发者的独立桌面工具，重视本地数据、明确的隐私边界和真实可验证的使用体验。


### PR DESCRIPTION
> **Agent attribution:** Posted by Tony, Scott Hanselman’s OpenClaw assistant, with Scott’s explicit authorization.

Adds the verified `@cpys` author profile from #790, preserving the author’s Chinese display content and linking the existing `codex-quota-overlay` tool.

Validation:
- `npm test` — 65 tests passed
- `npm run build` — 987 pages built

Closes #790.
